### PR TITLE
refactor(location): disable gps tracking for gallery image source`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 .svn/
 .swiftpm/
 migrate_working_dir/
+/tutor.md
+/review.md
 
 # IntelliJ related
 *.iml
@@ -67,4 +69,3 @@ Thumbs.db
 # AI
 .agent/
 .claude/
-/tutor.md

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-VisioSoil lets agronomists and field professionals photograph soil samples, record GPS coordinates, and review captured data — with on-device AI classification planned for a future phase. The app is the production-mobile evolution of academic research presented at ConBAP, which benchmarked the SqueezeNet architecture against manual feature extraction methods (FFT, Gabor, LBP) for soil texture classification.
+VisioSoil lets agronomists and field professionals photograph soil samples, record GPS coordinates, and review captured data — with on-device AI classification planned for a future phase. The app is the production-mobile evolution of academic research for soil texture classification.
 
 ## Tech Stack
 

--- a/lib/core/features/capture/capture_screen.dart
+++ b/lib/core/features/capture/capture_screen.dart
@@ -26,15 +26,6 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen> {
   String? _address;
   double? _latitude;
   double? _longitude;
-  bool _isFromGallery = false;
-  bool _useCurrentLocation = true;
-  final _addressController = TextEditingController();
-
-  @override
-  void dispose() {
-    _addressController.dispose();
-    super.dispose();
-  }
 
   Future<void> _pickImage(ImageSource source) async {
     final picker = ImagePicker();
@@ -42,21 +33,16 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen> {
 
     if (image == null) return;
 
-    ref.read(imageProvider.notifier).setImage(File(image.path));
-
-    final isGallery = source == ImageSource.gallery;
+    ref.read(imageProvider.notifier).setImage(File(image.path), source);
 
     setState(() {
-      _isFromGallery = isGallery;
-      _useCurrentLocation = !isGallery; // Câmera usa GPS, galeria não
       _address = null;
       _latitude = null;
       _longitude = null;
-      _addressController.clear();
     });
 
-    // Para câmera, obtém localização automaticamente
-    if (!isGallery) {
+    // Apenas imagens da câmera devem acionar geolocalização.
+    if (source == ImageSource.camera) {
       await _fetchCurrentLocation();
     }
   }
@@ -88,41 +74,18 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen> {
     }
   }
 
-  void _toggleLocationMode(bool useCurrentLocation) {
-    setState(() {
-      _useCurrentLocation = useCurrentLocation;
-      if (useCurrentLocation) {
-        _addressController.clear();
-        _fetchCurrentLocation();
-      } else {
-        _address = null;
-        _latitude = null;
-        _longitude = null;
-      }
-    });
-  }
-
   Future<void> _saveRecord() async {
-    final image = ref.read(imageProvider);
+    final selectedImage = ref.read(imageProvider);
+    final image = selectedImage.file;
     if (image == null) return;
 
-    // Determina o endereço final
-    String finalAddress;
-    double finalLatitude;
-    double finalLongitude;
+    final isGallery = selectedImage.source == ImageSource.gallery;
 
-    if (_useCurrentLocation) {
-      finalAddress = _address ?? 'Localização não disponível';
-      finalLatitude = _latitude ?? 0;
-      finalLongitude = _longitude ?? 0;
-    } else {
-      final manualAddress = _addressController.text.trim();
-      finalAddress = manualAddress.isNotEmpty
-          ? manualAddress
-          : 'Localização não informada';
-      finalLatitude = 0;
-      finalLongitude = 0;
-    }
+    final String? finalAddress = isGallery
+        ? null
+        : (_address ?? 'Localização não disponível');
+    final double? finalLatitude = isGallery ? null : _latitude;
+    final double? finalLongitude = isGallery ? null : _longitude;
 
     final box = Hive.box<SoilRecord>(StorageKeys.soilRecordsBox);
     box.add(
@@ -151,16 +114,15 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen> {
       _address = null;
       _latitude = null;
       _longitude = null;
-      _isFromGallery = false;
-      _useCurrentLocation = true;
-      _addressController.clear();
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    final image = ref.watch(imageProvider);
-    final hasImage = image != null;
+    final selectedImage = ref.watch(imageProvider);
+    final image = selectedImage.file;
+    final hasImage = selectedImage.hasImage;
+    final isFromGallery = selectedImage.source == ImageSource.gallery;
 
     return Scaffold(
       appBar: const VisioAppBar(title: 'Nova Captura'),
@@ -176,10 +138,7 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen> {
                   image: image,
                   isLoading: _isLoading,
                   address: _address,
-                  isFromGallery: _isFromGallery,
-                  useCurrentLocation: _useCurrentLocation,
-                  addressController: _addressController,
-                  onLocationModeChanged: _toggleLocationMode,
+                  isFromGallery: isFromGallery,
                 ),
               ),
               const SizedBox(height: AppSpacing.lg),
@@ -235,9 +194,6 @@ class _ImagePreview extends StatelessWidget {
     required this.image,
     required this.isLoading,
     required this.isFromGallery,
-    required this.useCurrentLocation,
-    required this.addressController,
-    required this.onLocationModeChanged,
     this.address,
   });
 
@@ -245,9 +201,6 @@ class _ImagePreview extends StatelessWidget {
   final bool isLoading;
   final String? address;
   final bool isFromGallery;
-  final bool useCurrentLocation;
-  final TextEditingController addressController;
-  final ValueChanged<bool> onLocationModeChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -266,7 +219,9 @@ class _ImagePreview extends StatelessWidget {
               Icon(
                 Icons.add_a_photo,
                 size: 64,
-                color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+                color: theme.colorScheme.onSurfaceVariant.withValues(
+                  alpha: 0.5,
+                ),
               ),
               const SizedBox(height: AppSpacing.md),
               Text(
@@ -304,49 +259,29 @@ class _ImagePreview extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // Opções de localização para galeria
               if (isFromGallery) ...[
                 Row(
                   children: [
                     Icon(
-                      Icons.location_on,
+                      Icons.info_outline,
                       size: 20,
                       color: theme.colorScheme.primary,
                     ),
                     const SizedBox(width: AppSpacing.sm),
                     Text(
-                      'Localização',
+                      'Localização indisponível',
                       style: theme.textTheme.titleSmall,
                     ),
                   ],
                 ),
-                const SizedBox(height: AppSpacing.md),
-                // Toggle entre GPS e manual
-                Row(
-                  children: [
-                    Expanded(
-                      child: _LocationOptionChip(
-                        label: 'GPS atual',
-                        icon: Icons.my_location,
-                        isSelected: useCurrentLocation,
-                        onTap: () => onLocationModeChanged(true),
-                      ),
-                    ),
-                    const SizedBox(width: AppSpacing.sm),
-                    Expanded(
-                      child: _LocationOptionChip(
-                        label: 'Manual',
-                        icon: Icons.edit_location_alt,
-                        isSelected: !useCurrentLocation,
-                        onTap: () => onLocationModeChanged(false),
-                      ),
-                    ),
-                  ],
+                const SizedBox(height: AppSpacing.sm),
+                Text(
+                  'Imagens da galeria não recebem coordenadas GPS para preservar a confiabilidade do registro.',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
                 ),
-                const SizedBox(height: AppSpacing.md),
-              ],
-              // Conteúdo baseado no modo
-              if (useCurrentLocation) ...[
+              ] else ...[
                 if (isLoading)
                   Row(
                     children: [
@@ -367,16 +302,14 @@ class _ImagePreview extends StatelessWidget {
                 else
                   Row(
                     children: [
-                      if (!isFromGallery) ...[
-                        Icon(
-                          Icons.location_on,
-                          size: 20,
-                          color: address != null
-                              ? theme.colorScheme.primary
-                              : theme.colorScheme.error,
-                        ),
-                        const SizedBox(width: AppSpacing.sm),
-                      ],
+                      Icon(
+                        Icons.location_on,
+                        size: 20,
+                        color: address != null
+                            ? theme.colorScheme.primary
+                            : theme.colorScheme.error,
+                      ),
+                      const SizedBox(width: AppSpacing.sm),
                       Expanded(
                         child: Text(
                           address ?? 'Localização não disponível',
@@ -387,94 +320,11 @@ class _ImagePreview extends StatelessWidget {
                       ),
                     ],
                   ),
-              ] else ...[
-                TextField(
-                  controller: addressController,
-                  decoration: InputDecoration(
-                    hintText: 'Digite o endereço ou descrição do local',
-                    hintStyle: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    contentPadding: const EdgeInsets.symmetric(
-                      horizontal: AppSpacing.md,
-                      vertical: AppSpacing.sm,
-                    ),
-                    isDense: true,
-                  ),
-                  style: theme.textTheme.bodyMedium,
-                  maxLines: 2,
-                  textInputAction: TextInputAction.done,
-                ),
               ],
             ],
           ),
         ),
       ],
-    );
-  }
-}
-
-class _LocationOptionChip extends StatelessWidget {
-  const _LocationOptionChip({
-    required this.label,
-    required this.icon,
-    required this.isSelected,
-    required this.onTap,
-  });
-
-  final String label;
-  final IconData icon;
-  final bool isSelected;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        padding: const EdgeInsets.symmetric(
-          horizontal: AppSpacing.md,
-          vertical: AppSpacing.sm,
-        ),
-        decoration: BoxDecoration(
-          color: isSelected
-              ? theme.colorScheme.primaryContainer
-              : theme.colorScheme.surface,
-          borderRadius: BorderRadius.circular(8),
-          border: Border.all(
-            color: isSelected
-                ? theme.colorScheme.primary
-                : theme.colorScheme.outline,
-          ),
-        ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              icon,
-              size: 18,
-              color: isSelected
-                  ? theme.colorScheme.primary
-                  : theme.colorScheme.onSurfaceVariant,
-            ),
-            const SizedBox(width: AppSpacing.xs),
-            Text(
-              label,
-              style: theme.textTheme.labelMedium?.copyWith(
-                color: isSelected
-                    ? theme.colorScheme.primary
-                    : theme.colorScheme.onSurfaceVariant,
-                fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
-              ),
-            ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/lib/core/features/details/details.dart
+++ b/lib/core/features/details/details.dart
@@ -11,10 +11,7 @@ import 'package:visiosoil_app/core/widgets/visio_card.dart';
 import 'package:visiosoil_app/models/soil_record.dart';
 
 class DetailsPage extends StatelessWidget {
-  const DetailsPage({
-    super.key,
-    required this.recordIndex,
-  });
+  const DetailsPage({super.key, required this.recordIndex});
 
   final int recordIndex;
 
@@ -60,10 +57,7 @@ class _RecordNotFoundView extends StatelessWidget {
 }
 
 class _DetailsContent extends StatelessWidget {
-  const _DetailsContent({
-    required this.record,
-    required this.recordIndex,
-  });
+  const _DetailsContent({required this.record, required this.recordIndex});
 
   final SoilRecord record;
   final int recordIndex;
@@ -189,32 +183,39 @@ class _LocationCard extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(height: AppSpacing.xs),
-                    Text(record.displayAddress, style: theme.textTheme.bodyLarge),
+                    Text(
+                      record.hasValidAddress
+                          ? record.displayAddress
+                          : 'Indisponível para imagens da galeria',
+                      style: theme.textTheme.bodyLarge,
+                    ),
                   ],
                 ),
               ),
             ],
           ),
-          const SizedBox(height: AppSpacing.md),
-          const Divider(height: 1),
-          const SizedBox(height: AppSpacing.md),
-          Row(
-            children: [
-              Expanded(
-                child: _CoordinateItem(
-                  label: 'Latitude',
-                  value: record.latitude.toStringAsFixed(6),
+          if (record.hasCoordinates) ...[
+            const SizedBox(height: AppSpacing.md),
+            const Divider(height: 1),
+            const SizedBox(height: AppSpacing.md),
+            Row(
+              children: [
+                Expanded(
+                  child: _CoordinateItem(
+                    label: 'Latitude',
+                    value: record.latitude!.toStringAsFixed(6),
+                  ),
                 ),
-              ),
-              const SizedBox(width: AppSpacing.md),
-              Expanded(
-                child: _CoordinateItem(
-                  label: 'Longitude',
-                  value: record.longitude.toStringAsFixed(6),
+                const SizedBox(width: AppSpacing.md),
+                Expanded(
+                  child: _CoordinateItem(
+                    label: 'Longitude',
+                    value: record.longitude!.toStringAsFixed(6),
+                  ),
                 ),
-              ),
-            ],
-          ),
+              ],
+            ),
+          ],
         ],
       ),
     );
@@ -222,10 +223,7 @@ class _LocationCard extends StatelessWidget {
 }
 
 class _CoordinateItem extends StatelessWidget {
-  const _CoordinateItem({
-    required this.label,
-    required this.value,
-  });
+  const _CoordinateItem({required this.label, required this.value});
 
   final String label;
   final String value;
@@ -300,9 +298,9 @@ class _DeleteButton extends StatelessWidget {
     }
 
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Registro excluído.')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Registro excluído.')));
       // Volta para o histórico, pulando a tela de preview
       context.go('/');
     }

--- a/lib/core/features/preview/image_preview_screen.dart
+++ b/lib/core/features/preview/image_preview_screen.dart
@@ -8,10 +8,7 @@ import 'package:visiosoil_app/core/theme/app_spacing.dart';
 import 'package:visiosoil_app/models/soil_record.dart';
 
 class ImagePreviewScreen extends StatelessWidget {
-  const ImagePreviewScreen({
-    super.key,
-    required this.recordIndex,
-  });
+  const ImagePreviewScreen({super.key, required this.recordIndex});
 
   final int recordIndex;
 
@@ -67,10 +64,7 @@ class _RecordNotFoundView extends StatelessWidget {
 }
 
 class _PreviewContent extends StatelessWidget {
-  const _PreviewContent({
-    required this.record,
-    required this.recordIndex,
-  });
+  const _PreviewContent({required this.record, required this.recordIndex});
 
   final SoilRecord record;
   final int recordIndex;
@@ -81,7 +75,9 @@ class _PreviewContent extends StatelessWidget {
       backgroundColor: Colors.black,
       body: Column(
         children: [
-          Expanded(child: _ImageViewer(record: record, recordIndex: recordIndex)),
+          Expanded(
+            child: _ImageViewer(record: record, recordIndex: recordIndex),
+          ),
           _InfoPanel(record: record),
         ],
       ),
@@ -90,10 +86,7 @@ class _PreviewContent extends StatelessWidget {
 }
 
 class _ImageViewer extends StatelessWidget {
-  const _ImageViewer({
-    required this.record,
-    required this.recordIndex,
-  });
+  const _ImageViewer({required this.record, required this.recordIndex});
 
   final SoilRecord record;
   final int recordIndex;
@@ -111,7 +104,11 @@ class _ImageViewer extends StatelessWidget {
           child: Center(
             child: imageFile.existsSync()
                 ? Image.file(imageFile, fit: BoxFit.contain)
-                : const Icon(Icons.broken_image, color: Colors.white54, size: 64),
+                : const Icon(
+                    Icons.broken_image,
+                    color: Colors.white54,
+                    size: 64,
+                  ),
           ),
         ),
         _TopBar(recordIndex: recordIndex),
@@ -155,10 +152,7 @@ class _TopBar extends StatelessWidget {
 }
 
 class _CircleIconButton extends StatelessWidget {
-  const _CircleIconButton({
-    required this.icon,
-    required this.onPressed,
-  });
+  const _CircleIconButton({required this.icon, required this.onPressed});
 
   final IconData icon;
   final VoidCallback onPressed;
@@ -203,16 +197,16 @@ class _InfoPanel extends StatelessWidget {
                 label: 'Capturado em',
                 value: record.formattedTimestamp,
               ),
-              if (record.hasValidAddress || record.hasCoordinates) ...[
-                const SizedBox(height: AppSpacing.md),
-                _InfoRow(
-                  icon: Icons.location_on,
-                  label: 'Localização',
-                  value: record.hasValidAddress
-                      ? record.address
-                      : record.formattedCoordinates,
-                ),
-              ],
+              const SizedBox(height: AppSpacing.md),
+              _InfoRow(
+                icon: Icons.location_on,
+                label: 'Localização',
+                value: record.hasValidAddress
+                    ? record.address!
+                    : (record.hasCoordinates
+                          ? record.formattedCoordinates
+                          : 'Indisponível para imagens da galeria'),
+              ),
               if (record.hasCoordinates && record.hasValidAddress) ...[
                 const SizedBox(height: AppSpacing.sm),
                 _CoordinatesSubtext(coordinates: record.formattedCoordinates),

--- a/lib/models/soil_record.dart
+++ b/lib/models/soil_record.dart
@@ -9,45 +9,49 @@ class SoilRecord {
   final String imagePath;
 
   @HiveField(1)
-  final double latitude;
+  final double? latitude;
 
   @HiveField(2)
-  final double longitude;
+  final double? longitude;
 
   @HiveField(3)
-  final String address;
+  final String? address;
 
   @HiveField(4)
   final String timestamp;
 
   SoilRecord({
     required this.imagePath,
-    required this.latitude,
-    required this.longitude,
-    required this.address,
+    this.latitude,
+    this.longitude,
+    this.address,
     required this.timestamp,
   });
 
   /// Indica se o registro possui coordenadas GPS válidas.
-  bool get hasCoordinates => latitude != 0 || longitude != 0;
+  bool get hasCoordinates => latitude != null && longitude != null;
 
   /// Indica se o registro possui um endereço válido.
   bool get hasValidAddress =>
-      address.isNotEmpty &&
+      address != null &&
+      address!.isNotEmpty &&
       address != 'Localização não disponível' &&
-      address != 'Localização não informada';
+      address != 'Localização não informada' &&
+      address != 'Localização indisponível para imagens da galeria';
 
   /// Retorna o timestamp formatado para exibição.
   String get formattedTimestamp => Formatters.timestamp(timestamp);
 
   /// Retorna o timestamp formatado de forma compacta.
-  String get formattedTimestampCompact => Formatters.timestampCompact(timestamp);
+  String get formattedTimestampCompact =>
+      Formatters.timestampCompact(timestamp);
 
   /// Retorna as coordenadas formatadas.
-  String get formattedCoordinates =>
-      Formatters.coordinates(latitude, longitude);
+  String get formattedCoordinates => hasCoordinates
+      ? Formatters.coordinates(latitude!, longitude!)
+      : 'Coordenadas não disponíveis';
 
   /// Retorna o endereço ou uma mensagem padrão.
   String get displayAddress =>
-      hasValidAddress ? address : 'Endereço não disponível';
+      hasValidAddress ? address! : 'Endereço não disponível';
 }

--- a/lib/providers/image_provider.dart
+++ b/lib/providers/image_provider.dart
@@ -1,21 +1,31 @@
-import "dart:io";
+import 'dart:io';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
 
-class ImageNotifier extends Notifier<File?> {
+class SelectedImageState {
+  const SelectedImageState({this.file, this.source});
+
+  final File? file;
+  final ImageSource? source;
+
+  bool get hasImage => file != null;
+}
+
+class ImageNotifier extends Notifier<SelectedImageState> {
   @override
-  File? build() {
-    return null;
+  SelectedImageState build() {
+    return const SelectedImageState();
   }
 
-  void setImage(File image) {
-    state = image;
+  void setImage(File image, ImageSource source) {
+    state = SelectedImageState(file: image, source: source);
   }
 
   void clearImage() {
-    state = null;
+    state = const SelectedImageState();
   }
 }
 
-final imageProvider = NotifierProvider<ImageNotifier, File?>(
+final imageProvider = NotifierProvider<ImageNotifier, SelectedImageState>(
   ImageNotifier.new,
 );


### PR DESCRIPTION
## 1. Contexto

Imagens vindas da galeria podem carregar metadados de tempo e lugar que não correspondem ao momento da coleta de solo. A issue exige não vincular GPS a esse tipo de origem, preservando a integridade dos registros e da análise agronômica.

**Motivação:** desativar rastreamento de localização para `ImageSource.gallery`; manter GPS apenas para `ImageSource.camera`.  
**Link da tarefa:** Issue #12 
**Closes:** #12 

## 2. O que foi feito?

Resumo técnico das mudanças **em relação à branch `origin/dev`**:

- **Riverpod (`lib/providers/image_provider.dart`):** estado passou a incluir arquivo selecionado + `ImageSource` (origem câmera vs galeria).
- **Captura (`lib/core/features/capture/capture_screen.dart`):** geolocalização (`LocationService` + geocoding) só após escolha pela **câmera**; galeria exibe aviso de localização indisponível e não persiste coordenadas; remoção do fluxo manual/GPS para galeria.
- **Modelo (`lib/models/soil_record.dart`):** `latitude`, `longitude` e `address` opcionais; ajuste de getters (`hasCoordinates`, `hasValidAddress`, formatação) para ausência real de dados.
- **Preview (`lib/core/features/preview/image_preview_screen.dart`):** painel de localização trata registro sem endereço nem coordenadas com mensagem explícita para galeria.
- **Detalhes (`lib/core/features/details/details.dart`):** cartão de localização e bloco de latitude/longitude só quando há coordenadas; mensagem quando não há localização válida.
- **Documentação e ignore (commits adicionais vs `dev`):** alinhamento de `README.md` e entradas em `.gitignore` ao fluxo atual do projeto.

_Nota:_ não há diff de `lib/models/soil_record.g.dart` entre `origin/dev` e o HEAD atual; se o adaptador Hive no seu ambiente divergir, rode `flutter pub run build_runner build --delete-conflicting-outputs` após merge.

## 3. Comparativo: branch atual × `origin/dev`

**Branch atual (exemplo):** `12-refactorlocation-desabilitar-rastreamento-de-localização-para-imagens-da-galeria`  
**Base de comparação:** `origin/dev`

### Commits em `HEAD` que não estão em `origin/dev`

| Commit     | Mensagem |
|-----------|----------|
| `605c9e7` | `docs(chore): align README and gitignore with current project workflow` |
| `b8e4449` | `feat(location): disable gps tracking for gallery image source` |

### Estatística do diff (`git diff origin/dev...HEAD --stat`)

```text
 .gitignore                                         |   5 +-
 README.md                                          |   2 +-
 lib/core/features/capture/capture_screen.dart      | 222 ++++-----------------
 lib/core/features/details/details.dart             |  66 +++---
 lib/core/features/preview/image_preview_screen.dart|  50 ++---
 lib/models/soil_record.dart                        |  32 +--
 lib/providers/image_provider.dart                  |  28 ++-
 7 files changed, 131 insertions(+), 274 deletions(-)
```

### Arquivos alterados (lista)

- `.gitignore`
- `README.md`
- `lib/core/features/capture/capture_screen.dart`
- `lib/core/features/details/details.dart`
- `lib/core/features/preview/image_preview_screen.dart`
- `lib/models/soil_record.dart`
- `lib/providers/image_provider.dart`

## 4. Como testar?

1. Atualize referências e mude para a branch da PR:  
   `git fetch origin`  
   `git checkout <sua-branch>`
2. Dependências: `flutter pub get`
3. Executar: `flutter run`
4. **Câmera:** capturar foto → confirmar obtenção de localização → salvar → conferir preview e detalhes com coordenadas/endereço quando aplicável.
5. **Galeria:** escolher foto → confirmar mensagem de localização indisponível → salvar → conferir preview e detalhes **sem** coordenadas persistidas.
6. (Opcional) `flutter pub run build_runner build --delete-conflicting-outputs` se o Hive adapter precisar ser regenerado localmente.

## 5. Evidências (Screenshots ou Vídeos)

_Inserir capturas: fluxo câmera (com localização) e fluxo galeria (mensagem de indisponibilidade + registro salvo sem coordenadas)._

## 6. Checklist de Auto-Revisão (RA)

- [ ] Realizei a auto-revisão na aba **Files changed** (diff contra `dev`).
- [ ] Removi códigos comentados e logs desnecessários.
- [ ] O código segue o guia de estilo do projeto.
- [ ] Fluxo câmera mantém GPS; fluxo galeria não persiste coordenadas inválidas.
- [ ] Build local passa após `flutter pub get` (e `build_runner` se necessário).