### PR TITLE
ci(pipeline): pin flutter 3.38.5 e adicionar concurrency group

### DIFF
--- a/.claude/registry.md
+++ b/.claude/registry.md
@@ -19,19 +19,22 @@
 | # | Data | Task | Complexidade | Escopo Alterado | Resultado | Observações |
 |---|------|------|--------------|-----------------|-----------|-------------|
 | — | — | — | — | — | — | Histórico pré-governance não rastreado. Projeto iniciou governança a partir desta data. |
+| 1 | 2026-04-28 | TASK-002 | minor | 1 arquivo — CI/CD | Pipeline validado, Flutter pinado 3.38.5, concurrency group adicionado | — |
+| 2 | 2026-04-28 | TASK-003 | major | revertida | Workflow claude-implement.yml criado e removido por solicitação do usuário | — |
+| 3 | 2026-04-28 | TASK-004 | minor | revertida | Validação invalidada pela reversão da TASK-003 | — |
 
 ## Estado da Codebase
 
 > Atualizado a cada implementação ou verificação pós-pull. Reflete o snapshot mais recente do projeto.
 
-- **Última atualização:** 2026-04-27
+- **Última atualização:** 2026-04-28
 - **Último responsável:** Claude Code (Opus 4)
 - **Branch ativa:** dev
 - **Versão:** 1.1.0
 - **Dependências alteradas recentemente:** nenhuma
 - **Testes passando:** sim (unit + repository)
 - **Divergências externas pendentes:** nenhuma
-- **Última task concluída:** — (governança recém-instalada)
+- **Última task concluída:** TASK-002 (validar CI/CD) — TASK-003 e TASK-004 revertidas
 - **Schema DB:** v2 (soil_records com texture_class, confidence_score)
 
 ## Pendências Conhecidas

--- a/.claude/tasks.md
+++ b/.claude/tasks.md
@@ -27,7 +27,76 @@
 
 ## Tasks Ativas
 
-[nenhuma task ativa]
+### TASK-001 — Integrar modelo SqueezeNet+LR para classificação de solo
+- **Tipo:** feat
+- **Complexidade:** minor
+- **Modo:** Desenvolvimento
+- **Status:** pausada
+- **Branch:** feat/TASK-001-squeezenet-lr-integration
+- **Escopo Técnico:**
+  - `lib/core/services/inference_service.dart` — atualizar labels, preprocessing (ImageNet normalization), output shape
+  - `scripts/convert_model.py` — script de conversão SqueezeNet+LR → TFLite (novo, ferramenta auxiliar)
+  - `assets/models/soil_classifier.tflite` — substituído pelo modelo combinado
+- **Critérios de Aceite:**
+  - [ ] Labels atualizadas para 5 classes (3 ativas + 2 futuras)
+  - [ ] Preprocessing com normalização ImageNet (mean/std por canal)
+  - [ ] Output shape dinâmico (lê do modelo, suporta 3 ou 5 classes)
+  - [ ] Script Python de conversão funcional
+  - [ ] `flutter analyze` sem erros
+  - [ ] Contrato `InferenceResult` inalterado
+- **Log de Andamento:**
+  - [2026-04-27] — Task registrada. Reconhecimento concluído. Implementação parcial iniciada e revertida — prioridade alterada pelo usuário.
+- **Resultado:** [pendente — pausada por prioridade]
+
+---
+
+### TASK-002 — Validar pipeline CI/CD existente
+- **Tipo:** ci
+- **Complexidade:** minor
+- **Modo:** Desenvolvimento
+- **Status:** concluída
+- **Branch:** ci/TASK-002-validar-ci-cd
+- **Escopo Técnico:**
+  - `.github/workflows/ci.yml` — revisar e corrigir pipeline (analyze → test → build)
+- **Critérios de Aceite:**
+  - [x] Pipeline `ci.yml` validado contra boas práticas (caching, dependências, steps redundantes)
+  - [x] Todos os jobs (analyze, test, build) executam corretamente
+  - [x] Artefato APK gerado no job build
+  - [x] `flutter analyze` passa localmente
+  - [x] `flutter test` passa localmente
+- **Log de Andamento:**
+  - [2026-04-27] — Task registrada.
+  - [2026-04-28] — Pipeline analisado. Melhorias: Flutter version pinada em 3.38.5, concurrency group adicionado. `flutter analyze` e `flutter test` passam (15/15).
+- **Resultado:** Pipeline validado. 2 melhorias aplicadas: (1) pin Flutter 3.38.5 para reprodutibilidade, (2) concurrency group para cancelar runs redundantes na mesma branch.
+
+---
+
+### TASK-003 — Configurar workflow de implementação automática por IA via label em issues
+- **Tipo:** ci
+- **Complexidade:** major
+- **Modo:** Desenvolvimento
+- **Status:** revertida
+- **Branch:** ci/TASK-003-ai-issue-automation
+- **Escopo Técnico:**
+  - `.github/workflows/claude-implement.yml` — removido por solicitação do usuário
+- **Log de Andamento:**
+  - [2026-04-27] — Task registrada.
+  - [2026-04-28] — Implementada e validada. Revertida por solicitação do usuário — arquivo removido.
+- **Resultado:** Revertida. Arquivo `.github/workflows/claude-implement.yml` removido.
+
+---
+
+### TASK-004 — Validar artefatos gerados contra regras .claude
+- **Tipo:** test
+- **Complexidade:** minor
+- **Modo:** Desenvolvimento
+- **Status:** revertida
+- **Branch:** test/TASK-004-validar-conformidade-claude
+- **Escopo Técnico:**
+  - Validação do workflow AI (TASK-003) — invalidada pela reversão da TASK-003
+- **Log de Andamento:**
+  - [2026-04-28] — Validação realizada. Revertida junto com TASK-003.
+- **Resultado:** Revertida — dependência (TASK-003) removida.
 
 ## Tasks Concluídas
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, dev]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     runs-on: ubuntu-latest
@@ -17,7 +21,7 @@ jobs:
           java-version: "17"
       - uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          flutter-version: "3.38.5"
           cache: true
       - run: flutter pub get
       - name: Generate Drift adapters
@@ -34,7 +38,7 @@ jobs:
           java-version: "17"
       - uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          flutter-version: "3.38.5"
           cache: true
       - name: Install SQLite (for Drift in-memory tests)
         run: sudo apt-get update && sudo apt-get install -y libsqlite3-0 libsqlite3-dev
@@ -54,7 +58,7 @@ jobs:
           java-version: "17"
       - uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          flutter-version: "3.38.5"
           cache: true
       - run: flutter pub get
       - name: Generate Drift adapters


### PR DESCRIPTION
## Descrição

**Task:** TASK-002
**Tipo:** ci
**Complexidade:** minor

Validação e melhoria do pipeline CI/CD existente.

## Mudanças Realizadas

- [x] Flutter version pinada em `3.38.5` (substituindo `channel: stable`) para reprodutibilidade
- [x] Concurrency group adicionado (`ci-${{ github.ref }}`) para cancelar runs redundantes na mesma branch
- [x] Registros de governança atualizados (tasks.md e registry.md)

## Escopo Técnico

**Arquivos alterados:**
- `.github/workflows/ci.yml`
- `.claude/tasks.md`
- `.claude/registry.md`

**Dependências adicionadas/removidas:**
- nenhuma

## Avaliação Pós-Implementação

```
✓ Conformidade: ok
✓ Qualidade: ok
✓ Impacto no escopo: ok — nenhum arquivo da app alterado
Decisão: pronto para merge
```

## Checklist de Auto-Revisão

- [x] Realizei a auto-revisão na aba "Files Changed"
- [x] Removi códigos comentados e prints desnecessários
- [x] O código segue o guia de estilo e convenções do projeto
- [x] As novas dependências funcionam sem quebrar o build atual
- [x] Nomes de variáveis e funções seguem o VAR Method
- [x] Commits seguem Conventional Commits
- [x] Avaliação pós-implementação foi executada e passou
- [x] `flutter analyze` passa sem erros
- [x] `flutter test` passa sem falhas