### PR TITLE
docs(license): add mit license and readme section

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 LukeSantossz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -155,3 +155,7 @@ visiosoil-app/
 ## Contributing
 
 Branch from `main` (`type/short-description`), keep `flutter analyze` and `flutter test` green, use single-line Conventional Commits (`type(scope): subject`), and open a PR with type and complexity labels.
+
+## License
+
+[MIT](LICENSE)

--- a/docs/specs/SPEC-readme-license.md
+++ b/docs/specs/SPEC-readme-license.md
@@ -1,0 +1,47 @@
+# SPEC: docs(license): add mit license and readme section
+
+## Problem
+
+The repository is public but declares no license, so default all-rights-reserved copyright applies, and the README is missing the License section that the framework's README Model marks as the mandatory final section.
+
+## Design Decision
+
+Add the standard MIT license text as `LICENSE` at the repository root with the copyright line "Copyright (c) 2026 LukeSantossz", and append the canonical `## License` section to the end of `README.md`, stating MIT and linking the file. MIT was chosen by the owner at the Spec Gate for this change (session decision, 2026-06-12). Specs for parallel changes live under `docs/specs/` so concurrent PRs do not collide on a single root `SPEC.md`; the root file remains the merged adoption spec.
+
+## Alternatives Considered
+
+- **Proprietary (all rights reserved, no LICENSE file):** rejected by the owner — the repository is a public portfolio project and permissive reuse is desired.
+- **Apache-2.0:** rejected — the explicit patent grant adds length and ceremony with no current need; MIT is simpler and was the owner's pick.
+- **GPL-3.0:** rejected — copyleft would constrain reuse of the code by others, which is not desired here.
+
+## Scope
+
+- Includes:
+  - `LICENSE` file at the repository root with the unmodified MIT text.
+  - `## License` section appended after Contributing as the final README section, per the README Model's canonical order.
+- Does NOT include:
+  - License headers in source files.
+  - `pubspec.yaml` metadata changes.
+  - Any README restructuring beyond the new section.
+  - A `CONTRIBUTING.md` file.
+
+## Acceptance Criteria
+
+- `license_file_contains_mit_text`: `LICENSE` exists at the root, starts with "MIT License", and contains the 2026 copyright line.
+- `readme_ends_with_license_section`: `## License` is the final section of `README.md`, states MIT, and links to `LICENSE`.
+- `readme_section_order_unchanged`: all pre-existing README sections remain in their current order; only the final section is added.
+
+## Reproducibility
+
+```bash
+head -3 LICENSE                      # expect: MIT License + copyright line
+grep -n '^## ' README.md | tail -3   # expect: ... Contributing, License (last)
+```
+
+No randomness involved; plain-text change.
+
+## Risks and Assumptions
+
+- The copyright holder is rendered as the GitHub handle "LukeSantossz" because no legal name is on file; the owner can amend the single line in review.
+- Assumes MIT is intended to cover the whole repository, including the `ml/` pipeline and placeholder model assets.
+- Invalidated if the owner later opts for a different license; the change is a two-file revert.


### PR DESCRIPTION
## 1. Context

**Motivation:** The repository is public but declares no license, so default all-rights-reserved copyright applies, and the README is missing the License section that the framework's README Model (`.standards/docs/standards/github.md`) marks as the mandatory final section. Follow-up from the my-framework adoption review (PR #39).

**Task Link:** none (no tracker in use).

**Spec Link:** [docs/specs/SPEC-readme-license.md](https://github.com/LukeSantossz/visiosoil-app/blob/docs/readme-license/docs/specs/SPEC-readme-license.md) — approved at the Spec Gate (license choice made by the owner in session, 2026-06-12).

## 2. What Was Done

- Added `LICENSE` at the repository root with the verbatim MIT text and the line "Copyright (c) 2026 LukeSantossz".
- Appended the canonical `## License` section as the final README section, stating MIT and linking the file.
- Added the spec under `docs/specs/` (parallel-change spec convention: one spec file per change so concurrent PRs do not collide on a single root `SPEC.md`).

## 3. How to Test

1. Check out the branch: `git checkout docs/readme-license`
2. `head -3 LICENSE` → expect "MIT License" and the 2026 copyright line.
3. `grep -n '^## ' README.md | tail -2` → expect Contributing then License as the final section.
4. `flutter analyze && flutter test` — unaffected; no Dart source is touched.

## 4. Evidence

Omitted: documentation-only change (per template rule for non-visual changes).

## 5. Self-Review Checklist

- [x] Self-review done: full diff reviewed by the author; human Review Again (CRURA RA stage) pending in the Files Changed tab before merge.
- [x] Spec approved at the Gate before implementation, and the change matches its Scope (per `spec_method.md`).
- [x] Acceptance criteria verified by command: MIT text verbatim, License is the final README section, pre-existing section order unchanged. Test-first does not apply: documentation-only change with no production code.
- [x] Commented-out code and unnecessary debug statements removed: none introduced.
- [x] Code follows the project style guide: no code changed.
- [x] New dependencies work without breaking the build: none added.
- [x] Review layers recorded: **R1** — internal subagent review ran against `code_conventions.md`, `github.md`, and `spec_method.md`; result: no findings. **R2** — not run: no second-provider reviewer is configured; per `ai_guidelines.md` Review Composition, R1 plus the human PR review stand in, recorded here. **R3** — CodeRabbit, runs automatically on this PR. Author model: Claude (Anthropic, via Claude Code); R1 reviewer: Claude subagent (same provider, hence R2 remains absent).

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9DkdzAbbXkJ5UAuBqKxhp)_