### PR TITLE
chore(github): add pr and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+Title: Conventional Commits format, type from the Type Table in
+.standards/docs/standards/github.md. Use fix for defects, not bug
+(e.g. refactor(database): migrate local storage to an actively supported alternative).
+Replace every HTML comment below with real content before submitting.
+-->
+
+## Description
+
+<!-- what needs to be done and why -->
+
+## Context
+
+<!-- history or technical motivation justifying the issue -->
+
+## Current Usage
+
+<!-- current state of what will change: entities, operations, affected dependencies -->
+
+## Recommended Alternative
+
+<!-- proposed solution and the criteria justifying it (name plus reasons) -->
+
+## Acceptance Criteria
+
+<!-- concrete deliverables that define the issue as complete -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041 -->
 <!--
 Title: Conventional Commits format, type from the Type Table in
 .standards/docs/standards/github.md. Use fix for defects, not bug

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!--
+Title: Conventional Commits format, type from the Type Table in
+.standards/docs/standards/github.md (e.g. feat(auth): implement password recovery).
+Labels: add one type label (feat, fix, ...) and one complexity label (patch, minor, major).
+Replace every HTML comment below with real content before requesting review.
+-->
+
+## 1. Context
+
+- **Motivation:** <!-- reason for the change -->
+- **Task Link:** <!-- tracker URL, or "none (no tracker in use)" -->
+- **Spec Link:** <!-- link to the approved SPEC for this change, or "none (trivial change)" -->
+
+## 2. What Was Done
+
+<!-- list the technical changes in summary form -->
+
+## 3. How to Test
+
+1. Check out the branch.
+2. Install dependencies: `flutter pub get` (run `dart run build_runner build --delete-conflicting-outputs` if DB tables changed).
+3. Run the checks: `flutter analyze && flutter test`.
+4. Verify the build runs without errors.
+
+## 4. Evidence
+
+<!-- screenshots or videos if the change is visual; omit this section if backend or configuration only -->
+
+## 5. Self-Review Checklist
+
+- [ ] Self-review done in the Files Changed tab.
+- [ ] Spec approved at the Gate before implementation, and the change matches its Scope (per `spec_method.md`).
+- [ ] Each Acceptance Criterion has a passing test; tests were written before their implementation.
+- [ ] Commented-out code and unnecessary debug statements removed.
+- [ ] Code follows the project style guide.
+- [ ] New dependencies work without breaking the build.
+- [ ] Review layers recorded: R1 internal review, R2 cross-provider review, R3 automated PR review where applicable, with Author and Reviewer models named (per `ai_guidelines.md` Review Composition). Note any layer that did not run and why.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041 -->
 <!--
 Title: Conventional Commits format, type from the Type Table in
 .standards/docs/standards/github.md (e.g. feat(auth): implement password recovery).
@@ -34,4 +35,4 @@ Replace every HTML comment below with real content before requesting review.
 - [ ] Commented-out code and unnecessary debug statements removed.
 - [ ] Code follows the project style guide.
 - [ ] New dependencies work without breaking the build.
-- [ ] Review layers recorded: R1 internal review, R2 cross-provider review, R3 automated PR review where applicable, with Author and Reviewer models named (per `ai_guidelines.md` Review Composition). Note any layer that did not run and why.
+- [ ] Review layers recorded: R1 internal review; R2 cross-provider review when a second-provider reviewer is available, otherwise R1 plus the human PR review stand in for R2 and the absence is noted here; R3 automated PR review where applicable. Name the Author and Reviewer models (per `ai_guidelines.md` Review Composition) and note any layer that did not run and why.

--- a/docs/specs/SPEC-github-templates.md
+++ b/docs/specs/SPEC-github-templates.md
@@ -1,0 +1,45 @@
+# SPEC: chore(github): add pr and issue templates
+
+## Problem
+
+PR and issue bodies follow the framework's `github.md` models only by convention — GitHub pre-fills nothing, so every author must reconstruct the required sections by hand, which invites drift.
+
+## Design Decision
+
+Add `.github/PULL_REQUEST_TEMPLATE.md` and `.github/ISSUE_TEMPLATE.md` mirroring the PR Model and Issue Model from `.standards/docs/standards/github.md`: same section headings in the same order, with placeholder guidance as HTML comments to be replaced with real content (per `ai_guidelines.md`, templates are filled, not left as placeholders). The templates carry no parallel rules or type vocabulary — they reference `github.md` as the single source. Specs for parallel changes live under `docs/specs/`; the root `SPEC.md` remains the merged adoption spec.
+
+## Alternatives Considered
+
+- **GitHub issue forms (`.github/ISSUE_TEMPLATE/*.yml`):** rejected — typed YAML forms are heavier to maintain, render differently from the markdown Issue Model, and the project has a single issue shape today.
+- **No templates (status quo):** rejected — manual reconstruction of sections drifts over time; the project's previous internal framework shipped templates and their removal left this gap.
+
+## Scope
+
+- Includes:
+  - `.github/PULL_REQUEST_TEMPLATE.md` mirroring the PR Model (Context, What Was Done, How to Test, Evidence, Self-Review Checklist with the review-layers item), plus a reminder of the project's type + complexity label rule.
+  - `.github/ISSUE_TEMPLATE.md` mirroring the Issue Model (Description, Context, Current Usage, Recommended Alternative, Acceptance Criteria).
+- Does NOT include:
+  - CODEOWNERS, CONTRIBUTING.md, or workflow changes.
+  - Multiple per-type issue templates or YAML issue forms.
+  - CI enforcement of template completion.
+
+## Acceptance Criteria
+
+- `pr_template_mirrors_pr_model_sections`: the PR template contains the five PR Model sections in order, including the review-layers checklist item.
+- `issue_template_mirrors_issue_model_sections`: the issue template contains the five Issue Model sections in order.
+- `templates_define_no_parallel_vocabulary`: neither template enumerates commit types; both point to `.standards/docs/standards/github.md`.
+
+## Reproducibility
+
+```bash
+grep -n '^## ' .github/PULL_REQUEST_TEMPLATE.md   # five PR Model sections in order
+grep -n '^## ' .github/ISSUE_TEMPLATE.md          # five Issue Model sections in order
+```
+
+No randomness involved; plain-text change.
+
+## Risks and Assumptions
+
+- GitHub applies `ISSUE_TEMPLATE.md` to every new issue (blank-issue fallback remains available via the UI).
+- HTML comments act as placeholders and are expected to be deleted when filling the template; an unfilled template submitted as-is is a process violation, not a template defect.
+- Invalidated if the team later adopts typed issue forms; the markdown files are then superseded.


### PR DESCRIPTION
## 1. Context

**Motivation:** PR and issue bodies follow the framework's `github.md` models only by convention — GitHub pre-fills nothing, so each author must reconstruct the required sections by hand, which invites drift. Follow-up from the my-framework adoption review (PR #39).

**Task Link:** none (no tracker in use).

**Spec Link:** [docs/specs/SPEC-github-templates.md](https://github.com/LukeSantossz/visiosoil-app/blob/chore/github-templates/docs/specs/SPEC-github-templates.md) — approved at the Spec Gate.

## 2. What Was Done

- Added `.github/PULL_REQUEST_TEMPLATE.md` mirroring the PR Model from `.standards/docs/standards/github.md`: the five sections in order (Context, What Was Done, How to Test, Evidence, Self-Review Checklist including the review-layers item), with placeholder guidance as HTML comments and a reminder of the project's type + complexity label rule.
- Added `.github/ISSUE_TEMPLATE.md` mirroring the Issue Model: Description, Context, Current Usage, Recommended Alternative, Acceptance Criteria.
- Neither template defines a parallel type vocabulary — both reference `github.md` as the single source.
- Added the spec under `docs/specs/` (parallel-change spec convention).
- After R3 review: suppressed markdownlint MD041 in both templates and reworded the review-layers checklist item to a conditional form that encodes the R2 fallback (`d8a7242`).

## 3. How to Test

1. Check out the branch: `git checkout chore/github-templates`
2. `grep -n '^## ' .github/PULL_REQUEST_TEMPLATE.md` → the five PR Model sections in order.
3. `grep -n '^## ' .github/ISSUE_TEMPLATE.md` → the five Issue Model sections in order.
4. After merge: opening a new PR or issue on GitHub pre-fills the corresponding template.

## 4. Evidence

Omitted: configuration-only change (per template rule for non-visual changes).

## 5. Self-Review Checklist

- [x] Self-review done: full diff reviewed by the author; human Review Again (CRURA RA stage) pending in the Files Changed tab before merge.
- [x] Spec approved at the Gate before implementation, and the change matches its Scope (per `spec_method.md`).
- [x] Acceptance criteria verified by command: both templates mirror their models' section names and order; no type vocabulary enumerated. Test-first does not apply: configuration-only change with no production code.
- [x] Commented-out code and unnecessary debug statements removed: the HTML comments in the templates are intentional placeholders defined by the spec, not leftovers.
- [x] Code follows the project style guide: no code changed.
- [x] New dependencies work without breaking the build: none added.
- [x] Review layers recorded: **R1** — internal subagent review ran against `code_conventions.md`, `github.md`, and `spec_method.md`; result: no findings. **R2** — not run: no second-provider reviewer is configured; per `ai_guidelines.md` Review Composition, R1 plus the human PR review stand in, recorded here. **R3** — CodeRabbit: two findings accepted and fixed in `d8a7242` (MD041 suppression in both templates; review-layers checklist reworded to a conditional that encodes the R2 fallback). One finding declined with justification: it suggested removing the Conventional Commits title guidance from the issue template as "PR-specific", but the Issue Model in `github.md` explicitly mandates Conventional Commits format for issue titles ("Use fix for defects, not bug"), so the template keeps mirroring the canonical source. Author model: Claude (Anthropic, via Claude Code); R1 reviewer: Claude subagent (same provider, hence R2 remains absent).