### PR TITLE
docs(lib): translate doc comments to english

### DIFF
--- a/docs/specs/SPEC-english-doc-comments.md
+++ b/docs/specs/SPEC-english-doc-comments.md
@@ -25,7 +25,7 @@ Translate every Portuguese comment (`///` dartdoc and `//` inline) in `lib/` and
 
 ## Acceptance Criteria
 
-- `no_accented_comment_chars_remain`: searching `lib/` and `test/` for comment lines containing accented characters returns zero matches.
+- `no_accented_comment_chars_remain`: searching `lib/` and `test/` for comment lines containing accented characters returns zero matches outside quoted product-output samples. Single documented exception: the dartdoc examples in `lib/core/utils/formatters.dart` quote the formatter's literal pt-BR output ("01/04/2026 às 14:30"), which is data, not Portuguese prose.
 - `no_unaccented_portuguese_comments_remain`: a manual sweep for accent-free Portuguese comment lines (e.g. "registro", "tela", "nao") returns none.
 - `strings_and_code_unchanged`: the diff touches only comment text — no string literal, identifier, or statement changes (verified line-by-line in review).
 - `analyzer_and_tests_unaffected`: `flutter analyze` and `flutter test` pass on CI exactly as on `main`, since comments cannot change semantics.
@@ -33,7 +33,7 @@ Translate every Portuguese comment (`///` dartdoc and `//` inline) in `lib/` and
 ## Reproducibility
 
 ```bash
-grep -rEn --include='*.dart' '//.*[áéíóúâêôãõç]' lib test | wc -l   # expect 0
+grep -rEn --include='*.dart' '//.*[áéíóúâêôãõç]' lib test | grep -v 'formatters.dart' | wc -l   # expect 0 (formatters.dart quotes literal pt-BR output)
 flutter analyze && flutter test                                      # via CI on the PR
 ```
 

--- a/docs/specs/SPEC-english-doc-comments.md
+++ b/docs/specs/SPEC-english-doc-comments.md
@@ -1,0 +1,46 @@
+# SPEC: docs(lib): translate doc comments to english
+
+## Problem
+
+103 comment lines across 24 Dart files in `lib/` and `test/` are written in Portuguese, violating the Language rule of `code_conventions.md` and the project's own `CLAUDE.md` convention that code comments are English.
+
+## Design Decision
+
+Translate every Portuguese comment (`///` dartdoc and `//` inline) in `lib/` and `test/` to precise technical English, preserving meaning, dartdoc structure (`[references]`, code spans), formatting, indentation, and comment placement. String literals (pt-BR user-facing product copy, exempt per `CLAUDE.md`), identifiers, and executable code remain byte-identical. Specs for parallel changes live under `docs/specs/`; the root `SPEC.md` remains the merged adoption spec.
+
+## Alternatives Considered
+
+- **Delete low-value comments instead of translating:** rejected — judging comment value is a separate cleanup with its own criteria; mixing it in makes this mechanical language alignment unreviewable.
+- **Translate gradually as files get touched:** rejected — leaves the codebase mixed-language indefinitely and spreads translation noise across unrelated future PRs.
+
+## Scope
+
+- Includes:
+  - Comment text in `lib/**/*.dart` and `test/**/*.dart` (24 files identified by sweep, plus any residual Portuguese comments found during review).
+- Does NOT include:
+  - Any change to string literals, identifiers, or executable code.
+  - Adding, removing, or rewording comments beyond translation.
+  - Fixing the address-sentinel mismatch listed in Known Technical Debt.
+  - README or other documentation files (already English).
+
+## Acceptance Criteria
+
+- `no_accented_comment_chars_remain`: searching `lib/` and `test/` for comment lines containing accented characters returns zero matches.
+- `no_unaccented_portuguese_comments_remain`: a manual sweep for accent-free Portuguese comment lines (e.g. "registro", "tela", "nao") returns none.
+- `strings_and_code_unchanged`: the diff touches only comment text — no string literal, identifier, or statement changes (verified line-by-line in review).
+- `analyzer_and_tests_unaffected`: `flutter analyze` and `flutter test` pass on CI exactly as on `main`, since comments cannot change semantics.
+
+## Reproducibility
+
+```bash
+grep -rEn --include='*.dart' '//.*[áéíóúâêôãõç]' lib test | wc -l   # expect 0
+flutter analyze && flutter test                                      # via CI on the PR
+```
+
+No randomness involved.
+
+## Risks and Assumptions
+
+- Translation fidelity is the main risk; mitigated by line-by-line diff review against the originals before the PR opens.
+- Assumes comments are the only non-string Portuguese content in the Dart sources (the accent sweep plus a stop-word sweep verify this).
+- Dartdoc `[symbol]` references and code spans are preserved verbatim, so generated docs links are unaffected.

--- a/lib/core/data/repositories/drift_soil_record_repository.dart
+++ b/lib/core/data/repositories/drift_soil_record_repository.dart
@@ -3,11 +3,11 @@ import 'package:visiosoil_app/core/data/repositories/soil_record_repository.dart
 import 'package:visiosoil_app/core/database/app_database.dart';
 import 'package:visiosoil_app/models/soil_record.dart';
 
-/// Implementação de [SoilRecordRepository] baseada em Drift/SQLite.
+/// Drift/SQLite-based implementation of [SoilRecordRepository].
 ///
-/// Concentra toda a conversão entre linhas Drift ([SoilRecordRow]) e o modelo
-/// de domínio [SoilRecord]. Nenhum tipo específico do Drift escapa por esta
-/// fronteira.
+/// Concentrates all conversion between Drift rows ([SoilRecordRow]) and the
+/// domain model [SoilRecord]. No Drift-specific type escapes through this
+/// boundary.
 class DriftSoilRecordRepository implements SoilRecordRepository {
   DriftSoilRecordRepository(this._db);
 
@@ -98,18 +98,18 @@ class DriftSoilRecordRepository implements SoilRecordRepository {
   }) {
     var query = _db.select(_db.soilRecords);
 
-    // Aplica filtros condicionalmente
+    // Applies filters conditionally
     query = query..where((t) {
       Expression<bool>? condition;
 
-      // Filtro por classe de textura (match exato)
+      // Filter by texture class (exact match)
       if (textureClass != null && textureClass.isNotEmpty) {
         condition = t.textureClass.equals(textureClass);
       }
 
-      // Filtro por termo de busca no endereco (LIKE case-insensitive)
-      // Remove wildcards SQL para evitar bypass de busca (% e _ sao tratados
-      // como caracteres literais ao serem removidos)
+      // Filter by search term on the address (case-insensitive LIKE)
+      // Removes SQL wildcards to prevent search bypass (% and _ are treated
+      // as literal characters by being removed)
       if (searchTerm != null && searchTerm.isNotEmpty) {
         final sanitized = searchTerm
             .replaceAll('%', '')
@@ -123,11 +123,11 @@ class DriftSoilRecordRepository implements SoilRecordRepository {
         }
       }
 
-      // Se nenhum filtro, retorna todos
+      // If no filter, returns all
       return condition ?? const Constant(true);
     });
 
-    // Ordena do mais recente ao mais antigo
+    // Orders from most recent to oldest
     query = query..orderBy([
       (t) => OrderingTerm(expression: t.id, mode: OrderingMode.desc),
     ]);

--- a/lib/core/data/repositories/soil_record_repository.dart
+++ b/lib/core/data/repositories/soil_record_repository.dart
@@ -1,50 +1,50 @@
 import 'package:visiosoil_app/models/soil_record.dart';
 
-/// Contrato de persistência para [SoilRecord].
+/// Persistence contract for [SoilRecord].
 ///
-/// A UI depende apenas desta interface: tipos específicos do Drift nunca
-/// vazam para as camadas de apresentação. Uma implementação baseada em outro
-/// mecanismo (ex.: API remota) poderia ser plugada sem alterar as telas.
+/// The UI depends only on this interface: Drift-specific types never
+/// leak into the presentation layers. An implementation based on another
+/// mechanism (e.g. a remote API) could be plugged in without changing the screens.
 abstract class SoilRecordRepository {
-  /// Persiste [record] e retorna uma cópia com o [SoilRecord.id] preenchido.
+  /// Persists [record] and returns a copy with the [SoilRecord.id] filled in.
   Future<SoilRecord> create(SoilRecord record);
 
-  /// Retorna o registro com o [id] informado ou `null` se não existir.
+  /// Returns the record with the given [id] or `null` if it does not exist.
   Future<SoilRecord?> getById(int id);
 
-  /// Emite a lista completa de registros, ordenada do mais recente ao mais
-  /// antigo, reagindo a mudanças no banco.
+  /// Emits the full list of records, ordered from most recent to oldest,
+  /// reacting to database changes.
   Stream<List<SoilRecord>> watchAll();
 
-  /// Lê a lista completa de registros, ordenada do mais recente ao mais
-  /// antigo, em uma única requisição.
+  /// Reads the full list of records, ordered from most recent to oldest,
+  /// in a single request.
   Future<List<SoilRecord>> getAll();
 
-  /// Retorna o registro mais recente ou `null` se o banco estiver vazio.
+  /// Returns the most recent record or `null` if the database is empty.
   Future<SoilRecord?> getLatest();
 
-  /// Retorna a quantidade total de registros.
+  /// Returns the total number of records.
   Future<int> count();
 
-  /// Remove o registro com o [id] informado. No-op se não existir.
+  /// Deletes the record with the given [id]. No-op if it does not exist.
   Future<void> deleteById(int id);
 
-  /// Remove em lote os registros cujos ids constam em [ids].
+  /// Deletes in batch the records whose ids are listed in [ids].
   Future<void> deleteByIds(List<int> ids);
 
-  /// Remove todos os registros do banco em uma unica operacao.
+  /// Deletes all records from the database in a single operation.
   Future<void> deleteAll();
 
-  /// Emite lista filtrada de registros, reagindo a mudancas no banco.
+  /// Emits a filtered list of records, reacting to database changes.
   ///
-  /// [textureClass] filtra por classe de textura (match exato).
-  /// [searchTerm] filtra por endereco (LIKE case-insensitive).
-  /// Se ambos forem null, comportamento identico a [watchAll].
+  /// [textureClass] filters by texture class (exact match).
+  /// [searchTerm] filters by address (case-insensitive LIKE).
+  /// If both are null, behavior is identical to [watchAll].
   Stream<List<SoilRecord>> watchFiltered({
     String? textureClass,
     String? searchTerm,
   });
 
-  /// Retorna lista de classes de textura distintas presentes no banco.
+  /// Returns the list of distinct texture classes present in the database.
   Future<List<String>> getDistinctTextureClasses();
 }

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -4,16 +4,16 @@ import 'package:visiosoil_app/core/database/tables/soil_records_table.dart';
 
 part 'app_database.g.dart';
 
-/// Banco de dados local do VisioSoil (SQLite + Drift).
+/// VisioSoil local database (SQLite + Drift).
 ///
-/// Contém apenas a tabela [SoilRecords] por enquanto. Futuras tabelas devem
-/// ser adicionadas ao array `tables` e acompanhadas de um aumento em
-/// [schemaVersion] com a respectiva migração em [migration].
+/// Contains only the [SoilRecords] table for now. Future tables must
+/// be added to the `tables` array and accompanied by a bump in
+/// [schemaVersion] with the corresponding migration in [migration].
 @DriftDatabase(tables: [SoilRecords])
 class AppDatabase extends _$AppDatabase {
   AppDatabase() : super(_openConnection());
 
-  /// Construtor usado em testes para injetar um [QueryExecutor] em memória.
+  /// Constructor used in tests to inject an in-memory [QueryExecutor].
   AppDatabase.forTesting(super.executor);
 
   @override
@@ -23,7 +23,7 @@ class AppDatabase extends _$AppDatabase {
   MigrationStrategy get migration => MigrationStrategy(
         onUpgrade: (migrator, from, to) async {
           if (from < 2) {
-            // v1 → v2: adiciona colunas de classificação de textura
+            // v1 → v2: adds texture classification columns
             await migrator.addColumn(soilRecords, soilRecords.textureClass);
             await migrator.addColumn(soilRecords, soilRecords.confidenceScore);
           }
@@ -32,7 +32,7 @@ class AppDatabase extends _$AppDatabase {
 }
 
 QueryExecutor _openConnection() {
-  // `driftDatabase` cuida do path do diretório de documentos, abertura lazy
-  // e isolate adequado em cada plataforma.
+  // `driftDatabase` takes care of the documents directory path, lazy opening,
+  // and the appropriate isolate on each platform.
   return driftDatabase(name: 'visiosoil');
 }

--- a/lib/core/database/tables/soil_records_table.dart
+++ b/lib/core/database/tables/soil_records_table.dart
@@ -1,9 +1,9 @@
 import 'package:drift/drift.dart';
 
-/// Tabela Drift para registros de solo.
+/// Drift table for soil records.
 ///
-/// O nome explícito da tabela (`soil_records`) evita colisão com o nome da
-/// classe Dart e segue a convenção snake_case do SQLite.
+/// The explicit table name (`soil_records`) avoids collision with the Dart
+/// class name and follows the SQLite snake_case convention.
 @DataClassName('SoilRecordRow')
 class SoilRecords extends Table {
   @override

--- a/lib/core/features/capture/capture_screen.dart
+++ b/lib/core/features/capture/capture_screen.dart
@@ -49,8 +49,8 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    // Revalida permissao quando o app volta ao foreground (ex: apos Settings)
-    // Nao revalida para `restricted` (iOS) pois nao pode ser alterado pelo usuario
+    // Revalidates permission when the app returns to the foreground (e.g. after Settings)
+    // Does not revalidate for `restricted` (iOS) since it cannot be changed by the user
     if (state == AppLifecycleState.resumed &&
         _cameraPermissionStatus == AppPermissionStatus.permanentlyDenied) {
       _recheckCameraPermission();
@@ -67,7 +67,7 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen>
   }
 
   Future<void> _pickImage() async {
-    // Verifica permissao de camera antes de abrir
+    // Checks camera permission before opening
     final status = await PermissionService.checkCamera();
     if (!mounted) return;
 
@@ -80,7 +80,7 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen>
         return;
       }
     }
-    // Limpa estado de permissao se concedida
+    // Clears the permission state if granted
     if (_cameraPermissionStatus != null) {
       setState(() => _cameraPermissionStatus = null);
     }
@@ -99,7 +99,7 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen>
       _classificationResult = null;
     });
 
-    // Executa localização e classificação em paralelo (são independentes)
+    // Runs location and classification in parallel (they are independent)
     await Future.wait([
       _fetchCurrentLocation(),
       _classifySoilTexture(image.path),
@@ -142,8 +142,8 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen>
         });
       }
     } catch (e) {
-      // Localizacao negada ou indisponivel: app funciona sem GPS
-      // O registro sera salvo com coordenadas null
+      // Location denied or unavailable: the app works without GPS
+      // The record will be saved with null coordinates
       if (mounted) {
         setState(() => _isLoading = false);
       }
@@ -151,7 +151,7 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen>
   }
 
   Future<void> _saveRecord() async {
-    // Guard contra double-tap
+    // Guard against double-tap
     if (_isSaving) return;
 
     final selectedImage = ref.read(imageProvider);
@@ -210,7 +210,7 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen>
 
   @override
   Widget build(BuildContext context) {
-    // Mostra tela de permissao negada se camera foi bloqueada
+    // Shows the permission denied screen if the camera was blocked
     if (_cameraPermissionStatus != null &&
         _cameraPermissionStatus != AppPermissionStatus.granted) {
       final isRestricted =
@@ -246,7 +246,7 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen>
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              // Preview da imagem
+              // Image preview
               Expanded(
                 child: _ImagePreview(
                   image: image,
@@ -257,7 +257,7 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen>
                 ),
               ),
               const SizedBox(height: AppSpacing.lg),
-              // Botões de ação
+              // Action buttons
               if (!hasImage) ...[
                 VisioButton(
                   label: 'Câmera',
@@ -349,7 +349,7 @@ class _ImagePreview extends StatelessWidget {
             fit: BoxFit.cover,
             width: double.infinity,
           ),
-          // Gradient para legibilidade dos chips
+          // Gradient for chip legibility
           Positioned(
             left: 0,
             right: 0,
@@ -368,7 +368,7 @@ class _ImagePreview extends StatelessWidget {
               ),
             ),
           ),
-          // Chips de info
+          // Info chips
           Positioned(
             left: AppSpacing.sm,
             right: AppSpacing.sm,

--- a/lib/core/features/capture/processing_screen.dart
+++ b/lib/core/features/capture/processing_screen.dart
@@ -3,10 +3,10 @@ import 'package:visiosoil_app/core/theme/app_colors.dart';
 import 'package:visiosoil_app/core/theme/app_radius.dart';
 import 'package:visiosoil_app/core/theme/app_spacing.dart';
 
-/// Tela de processamento exibida durante inferência TFLite.
+/// Processing screen displayed during TFLite inference.
 ///
-/// Recebe [imagePath] para exibir thumbnail da amostra e
-/// [onComplete] callback para quando a inferência terminar.
+/// Receives [imagePath] to display the sample thumbnail and
+/// the [onComplete] callback for when inference finishes.
 class ProcessingScreen extends StatefulWidget {
   const ProcessingScreen({super.key, this.imagePath});
 

--- a/lib/core/features/capture/setup_screen.dart
+++ b/lib/core/features/capture/setup_screen.dart
@@ -5,10 +5,10 @@ import 'package:visiosoil_app/core/theme/app_radius.dart';
 import 'package:visiosoil_app/core/theme/app_spacing.dart';
 import 'package:visiosoil_app/models/capture_context.dart';
 
-/// Tela de setup pré-captura com wizard de 2 passos.
+/// Pre-capture setup screen with a 2-step wizard.
 ///
-/// Permite selecionar cultura/época e profundidade antes de
-/// abrir a câmera para captura da amostra de solo.
+/// Allows selecting crop/season and depth before
+/// opening the camera to capture the soil sample.
 class SetupScreen extends StatefulWidget {
   const SetupScreen({super.key});
 
@@ -20,7 +20,7 @@ class _SetupScreenState extends State<SetupScreen> {
   final _pageController = PageController();
   int _currentStep = 0;
 
-  // Seleções do usuário
+  // User selections
   Crop? _selectedCrop;
   PlantingSeason? _selectedSeason;
   SamplingDepth? _selectedDepth;
@@ -61,7 +61,7 @@ class _SetupScreenState extends State<SetupScreen> {
       plantingSeason: _selectedSeason,
       samplingDepth: _selectedDepth,
     );
-    // Navega para a captura passando o contexto
+    // Navigates to capture passing the context
     context.go('/capture', extra: captureContext);
   }
 
@@ -155,7 +155,7 @@ class _SetupScreenState extends State<SetupScreen> {
   }
 }
 
-/// Indicador de progresso do wizard.
+/// Wizard progress indicator.
 class _ProgressIndicator extends StatelessWidget {
   const _ProgressIndicator({
     required this.currentStep,
@@ -201,7 +201,7 @@ class _ProgressIndicator extends StatelessWidget {
   }
 }
 
-/// Passo 1: Seleção de cultura e época.
+/// Step 1: Crop and season selection.
 class _CropSelectionStep extends StatelessWidget {
   const _CropSelectionStep({
     required this.selectedCrop,
@@ -222,7 +222,7 @@ class _CropSelectionStep extends StatelessWidget {
     return ListView(
       padding: const EdgeInsets.all(AppSpacing.lg),
       children: [
-        // Seção de cultura
+        // Crop section
         Text(
           'Qual cultura está plantada?',
           style: theme.textTheme.bodyLarge?.copyWith(
@@ -230,7 +230,7 @@ class _CropSelectionStep extends StatelessWidget {
           ),
         ),
         const SizedBox(height: AppSpacing.lg),
-        // Grid de culturas 2x3
+        // 2x3 crop grid
         GridView.count(
           crossAxisCount: 3,
           shrinkWrap: true,
@@ -247,7 +247,7 @@ class _CropSelectionStep extends StatelessWidget {
               .toList(),
         ),
         const SizedBox(height: AppSpacing.xxl),
-        // Seção de época
+        // Season section
         Text(
           'Época de plantio',
           style: theme.textTheme.bodyLarge?.copyWith(
@@ -255,7 +255,7 @@ class _CropSelectionStep extends StatelessWidget {
           ),
         ),
         const SizedBox(height: AppSpacing.md),
-        // Chips de época
+        // Season chips
         Wrap(
           spacing: AppSpacing.sm,
           runSpacing: AppSpacing.sm,
@@ -278,7 +278,7 @@ class _CropSelectionStep extends StatelessWidget {
   }
 }
 
-/// Card de seleção de cultura.
+/// Crop selection card.
 class _CropCard extends StatelessWidget {
   const _CropCard({
     required this.crop,
@@ -350,7 +350,7 @@ class _CropCard extends StatelessWidget {
   }
 }
 
-/// Passo 2: Seleção de profundidade + resumo.
+/// Step 2: Depth selection + summary.
 class _DepthSelectionStep extends StatelessWidget {
   const _DepthSelectionStep({
     required this.selectedDepth,
@@ -376,14 +376,14 @@ class _DepthSelectionStep extends StatelessWidget {
           ),
         ),
         const SizedBox(height: AppSpacing.lg),
-        // Cards de profundidade
+        // Depth cards
         ...SamplingDepth.values.map((depth) => _DepthCard(
               depth: depth,
               isSelected: selectedDepth == depth,
               onTap: () => onDepthSelected(depth),
             )),
         const SizedBox(height: AppSpacing.xxl),
-        // Resumo
+        // Summary
         if (context.crop != null) ...[
           Text(
             'Resumo',
@@ -427,7 +427,7 @@ class _DepthSelectionStep extends StatelessWidget {
   }
 }
 
-/// Card de seleção de profundidade.
+/// Depth selection card.
 class _DepthCard extends StatelessWidget {
   const _DepthCard({
     required this.depth,
@@ -522,7 +522,7 @@ class _DepthCard extends StatelessWidget {
   }
 }
 
-/// Linha de resumo.
+/// Summary row.
 class _SummaryRow extends StatelessWidget {
   const _SummaryRow({
     required this.icon,

--- a/lib/core/features/history/history_screen.dart
+++ b/lib/core/features/history/history_screen.dart
@@ -32,7 +32,7 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
   @override
   void initState() {
     super.initState();
-    // Sincroniza controller com provider persistido (ex: apos navegacao)
+    // Syncs the controller with the persisted provider (e.g. after navigation)
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final currentTerm = ref.read(searchTermProvider);
       if (currentTerm.isNotEmpty && _searchController.text != currentTerm) {
@@ -168,7 +168,7 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Campo de busca
+          // Search field
           Padding(
             padding: const EdgeInsets.fromLTRB(
               AppSpacing.md,
@@ -202,7 +202,7 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
               onChanged: _onSearchChanged,
             ),
           ),
-          // Chips de filtro por classe de textura
+          // Texture class filter chips
           availableClasses.when(
             loading: () => const SizedBox.shrink(),
             error: (error, stackTrace) => const SizedBox.shrink(),

--- a/lib/core/features/onboarding/onboarding_screen.dart
+++ b/lib/core/features/onboarding/onboarding_screen.dart
@@ -4,7 +4,7 @@ import 'package:visiosoil_app/core/theme/app_colors.dart';
 import 'package:visiosoil_app/core/theme/app_radius.dart';
 import 'package:visiosoil_app/core/theme/app_spacing.dart';
 
-/// Dados de cada passo do onboarding.
+/// Data for each onboarding step.
 class _OnboardingStep {
   const _OnboardingStep({
     required this.icon,
@@ -46,10 +46,10 @@ const _steps = [
   ),
 ];
 
-/// Onboarding de captura com 3 passos ilustrados.
+/// Capture onboarding with 3 illustrated steps.
 ///
-/// Usa [PageView] para navegação entre passos. O callback [onComplete]
-/// é chamado ao pressionar "Começar" no último passo.
+/// Uses [PageView] for navigation between steps. The [onComplete] callback
+/// is called when pressing the start button on the last step.
 class OnboardingScreen extends StatefulWidget {
   const OnboardingScreen({super.key, this.onComplete});
 

--- a/lib/core/features/result/result_screen.dart
+++ b/lib/core/features/result/result_screen.dart
@@ -10,9 +10,9 @@ import 'package:visiosoil_app/core/theme/soil_texture_colors.dart';
 import 'package:visiosoil_app/models/confidence_level.dart';
 import 'package:visiosoil_app/models/soil_record.dart';
 
-/// Tela de resultado apos classificacao.
+/// Result screen after classification.
 ///
-/// Recebe um [SoilRecord] via [GoRouter.extra] (ja persistido com id).
+/// Receives a [SoilRecord] via [GoRouter.extra] (already persisted with id).
 class ResultScreen extends ConsumerWidget {
   const ResultScreen({super.key, required this.record});
 

--- a/lib/core/features/settings/settings_screen.dart
+++ b/lib/core/features/settings/settings_screen.dart
@@ -7,7 +7,7 @@ import 'package:visiosoil_app/core/theme/app_radius.dart';
 import 'package:visiosoil_app/core/theme/app_spacing.dart';
 import 'package:visiosoil_app/providers/soil_record_repository_provider.dart';
 
-/// Provider para informacoes do app (versao, build).
+/// Provider for app information (version, build).
 final packageInfoProvider = FutureProvider<PackageInfo>((ref) {
   return PackageInfo.fromPlatform();
 });

--- a/lib/core/features/splash/splash_screen.dart
+++ b/lib/core/features/splash/splash_screen.dart
@@ -4,10 +4,10 @@ import 'package:visiosoil_app/core/services/permission_service.dart';
 import 'package:visiosoil_app/core/theme/app_colors.dart';
 import 'package:visiosoil_app/core/theme/app_spacing.dart';
 
-/// Tela de splash inicial do app.
+/// Initial splash screen of the app.
 ///
-/// Exibe logo do VisioSoil, solicita permissoes necessarias (camera e
-/// localizacao) e navega para a home apos conclusao.
+/// Displays the VisioSoil logo, requests the required permissions (camera and
+/// location), and navigates to home when finished.
 class SplashScreen extends StatefulWidget {
   const SplashScreen({super.key});
 
@@ -42,7 +42,7 @@ class _SplashScreenState extends State<SplashScreen>
 
     _animationController.forward();
 
-    // Inicia solicitacao de permissoes apos animacao inicial
+    // Starts the permission requests after the initial animation
     Future.delayed(const Duration(milliseconds: 1200), _requestPermissions);
   }
 
@@ -60,13 +60,13 @@ class _SplashScreenState extends State<SplashScreen>
       _statusMessage = 'Solicitando permissoes...';
     });
 
-    // Solicita permissao de camera
+    // Requests camera permission
     setState(() => _statusMessage = 'Permissao de camera...');
     await PermissionService.requestCamera();
 
     if (!mounted) return;
 
-    // Solicita permissao de localizacao
+    // Requests location permission
     setState(() => _statusMessage = 'Permissao de localizacao...');
     await PermissionService.requestLocation();
 
@@ -74,12 +74,12 @@ class _SplashScreenState extends State<SplashScreen>
 
     setState(() => _statusMessage = 'Iniciando...');
 
-    // Pequeno delay para transicao suave
+    // Small delay for a smooth transition
     await Future.delayed(const Duration(milliseconds: 500));
 
     if (!mounted) return;
 
-    // Navega para home
+    // Navigates to home
     context.go('/');
   }
 

--- a/lib/core/services/inference_service.dart
+++ b/lib/core/services/inference_service.dart
@@ -7,7 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:image/image.dart' as img;
 import 'package:tflite_flutter/tflite_flutter.dart';
 
-/// Resultado da inferência de classificação de textura do solo.
+/// Result of soil texture classification inference.
 class InferenceResult {
   final String textureClass;
   final double confidenceScore;
@@ -18,7 +18,7 @@ class InferenceResult {
   });
 }
 
-/// Parâmetros para execução de inferência em isolate.
+/// Parameters for running inference in an isolate.
 class _InferenceParams {
   final String imagePath;
   final Uint8List modelBytes;
@@ -29,19 +29,19 @@ class _InferenceParams {
   });
 }
 
-/// Serviço de inferência TensorFlow Lite para classificação de textura do solo.
+/// TensorFlow Lite inference service for soil texture classification.
 ///
-/// Carrega o modelo dos assets, pré-processa imagens e executa inferência
-/// on-device. A inferência é executada em isolate para não bloquear a thread
-/// principal.
+/// Loads the model from assets, preprocesses images, and runs inference
+/// on-device. Inference is executed in an isolate to avoid blocking the main
+/// thread.
 class InferenceService {
   static const String _modelPath = 'assets/models/soil_classifier.tflite';
 
-  /// Dimensão de entrada do modelo (224x224 RGB).
+  /// Model input dimension (224x224 RGB).
   static const int _inputSize = 224;
 
-  /// Classes de textura do solo alinhadas com ml/config.yaml.
-  /// A ordem deve corresponder às saídas do modelo treinado.
+  /// Soil texture classes aligned with ml/config.yaml.
+  /// The order must match the trained model's outputs.
   static const List<String> _textureLabels = [
     'Arenosa',
     'Media',
@@ -54,23 +54,23 @@ class InferenceService {
   bool _isInitialized = false;
   bool _initializationAttempted = false;
 
-  /// Indica se o serviço está pronto para inferência.
+  /// Indicates whether the service is ready for inference.
   bool get isReady => _isInitialized && _modelBytes != null;
 
-  /// Inicializa o serviço carregando o modelo dos assets.
+  /// Initializes the service by loading the model from assets.
   ///
-  /// Retorna `true` se inicializado com sucesso, `false` caso contrário.
-  /// O modelo é carregado como bytes para poder ser passado ao isolate.
-  /// Se a inicialização já foi tentada e falhou, retorna `false` imediatamente.
+  /// Returns `true` if initialized successfully, `false` otherwise.
+  /// The model is loaded as bytes so it can be passed to the isolate.
+  /// If initialization was already attempted and failed, returns `false` immediately.
   Future<bool> initialize() async {
     if (_isInitialized) return true;
 
-    // Evita tentativas repetidas de carregar modelo inexistente
+    // Avoids repeated attempts to load a nonexistent model
     if (_initializationAttempted) return false;
     _initializationAttempted = true;
 
     try {
-      // Timeout para evitar travamento se o arquivo não existir
+      // Timeout to avoid hanging if the file does not exist
       final byteData = await rootBundle.load(_modelPath).timeout(
         const Duration(seconds: 5),
         onTimeout: () => throw Exception('Timeout loading model'),
@@ -91,10 +91,10 @@ class InferenceService {
     }
   }
 
-  /// Executa classificação de textura do solo em uma imagem.
+  /// Runs soil texture classification on an image.
   ///
-  /// [imagePath] é o caminho absoluto da imagem a ser classificada.
-  /// Retorna `null` se o serviço não estiver inicializado ou se ocorrer erro.
+  /// [imagePath] is the absolute path of the image to classify.
+  /// Returns `null` if the service is not initialized or if an error occurs.
   Future<InferenceResult?> classify(String imagePath) async {
     if (!isReady) {
       final initialized = await initialize();
@@ -102,8 +102,8 @@ class InferenceService {
     }
 
     try {
-      // Executa inferência em isolate para não bloquear a UI
-      // Passa o modelo como bytes pois rootBundle não funciona em isolates
+      // Runs inference in an isolate to avoid blocking the UI
+      // Passes the model as bytes since rootBundle does not work in isolates
       final params = _InferenceParams(
         imagePath: imagePath,
         modelBytes: _modelBytes!,
@@ -119,10 +119,10 @@ class InferenceService {
     }
   }
 
-  /// Executa a inferência propriamente dita (chamada dentro do isolate).
+  /// Runs the actual inference (called inside the isolate).
   static Future<InferenceResult?> _runInference(_InferenceParams params) async {
     try {
-      // Carrega e pré-processa a imagem
+      // Loads and preprocesses the image
       final imageFile = File(params.imagePath);
       if (!imageFile.existsSync()) return null;
 
@@ -130,7 +130,7 @@ class InferenceService {
       final image = img.decodeImage(imageBytes);
       if (image == null) return null;
 
-      // Resize para o tamanho esperado pelo modelo
+      // Resizes to the size expected by the model
       final resized = img.copyResize(
         image,
         width: _inputSize,
@@ -138,10 +138,10 @@ class InferenceService {
         interpolation: img.Interpolation.linear,
       );
 
-      // Normaliza pixels para [0, 1] e converte para formato do modelo
+      // Normalizes pixels to [0, 1] and converts to the model's format
       final input = _imageToInputTensor(resized);
 
-      // Carrega o modelo a partir dos bytes (funciona em isolate)
+      // Loads the model from bytes (works in an isolate)
       final interpreter = Interpreter.fromBuffer(params.modelBytes);
 
       // Output shape: [1, numClasses]
@@ -149,11 +149,11 @@ class InferenceService {
       final numClasses = outputShape.last;
       final output = List.filled(numClasses, 0.0).reshape([1, numClasses]);
 
-      // Executa inferência
+      // Runs inference
       interpreter.run(input, output);
       interpreter.close();
 
-      // Encontra classe com maior probabilidade
+      // Finds the class with the highest probability
       final probabilities = (output[0] as List<double>);
       int maxIndex = 0;
       double maxProb = probabilities[0];
@@ -164,7 +164,7 @@ class InferenceService {
         }
       }
 
-      // Mapeia índice para label
+      // Maps index to label
       final label = maxIndex < _textureLabels.length
           ? _textureLabels[maxIndex]
           : 'Classe $maxIndex';
@@ -179,7 +179,7 @@ class InferenceService {
     }
   }
 
-  /// Converte imagem para tensor de entrada [1, 224, 224, 3] float32.
+  /// Converts an image to a [1, 224, 224, 3] float32 input tensor.
   static List<List<List<List<double>>>> _imageToInputTensor(img.Image image) {
     final input = List.generate(
       1,
@@ -189,7 +189,7 @@ class InferenceService {
           _inputSize,
           (x) {
             final pixel = image.getPixel(x, y);
-            // image 4.x retorna num para r/g/b (0-255 para imagens 8-bit)
+            // image 4.x returns num for r/g/b (0-255 for 8-bit images)
             return [
               pixel.r.toDouble() / 255.0,
               pixel.g.toDouble() / 255.0,
@@ -202,7 +202,7 @@ class InferenceService {
     return input;
   }
 
-  /// Libera recursos do serviço.
+  /// Releases the service's resources.
   void dispose() {
     _modelBytes = null;
     _isInitialized = false;

--- a/lib/core/services/permission_service.dart
+++ b/lib/core/services/permission_service.dart
@@ -1,58 +1,58 @@
 import 'package:permission_handler/permission_handler.dart' as ph;
 
-/// Status de permissão para uso na UI.
+/// Permission status for use in the UI.
 enum AppPermissionStatus {
-  /// Permissao concedida.
+  /// Permission granted.
   granted,
 
-  /// Permissao negada (pode ser solicitada novamente).
+  /// Permission denied (can be requested again).
   denied,
 
-  /// Permissao negada permanentemente (requer configuracoes do sistema).
+  /// Permission permanently denied (requires system settings).
   permanentlyDenied,
 
-  /// Permissao restrita pelo sistema (iOS parental controls, MDM).
-  /// Nao pode ser alterada pelo usuario.
+  /// Permission restricted by the system (iOS parental controls, MDM).
+  /// Cannot be changed by the user.
   restricted,
 }
 
-/// Servico para gerenciar permissoes do app.
+/// Service for managing app permissions.
 ///
-/// Encapsula verificacao, solicitacao e redirecionamento para configuracoes
-/// do sistema. Usa o pacote `permission_handler` internamente.
+/// Encapsulates checking, requesting, and redirecting to system
+/// settings. Uses the `permission_handler` package internally.
 class PermissionService {
   const PermissionService._();
 
-  /// Verifica o status atual da permissao de camera.
+  /// Checks the current camera permission status.
   static Future<AppPermissionStatus> checkCamera() async {
     return _toStatus(await ph.Permission.camera.status);
   }
 
-  /// Solicita permissao de camera.
+  /// Requests camera permission.
   ///
-  /// Retorna o status apos a solicitacao.
+  /// Returns the status after the request.
   static Future<AppPermissionStatus> requestCamera() async {
     final status = await ph.Permission.camera.request();
     return _toStatus(status);
   }
 
-  /// Verifica o status atual da permissao de localizacao.
+  /// Checks the current location permission status.
   static Future<AppPermissionStatus> checkLocation() async {
     return _toStatus(await ph.Permission.locationWhenInUse.status);
   }
 
-  /// Solicita permissao de localizacao.
+  /// Requests location permission.
   ///
-  /// Retorna o status apos a solicitacao.
+  /// Returns the status after the request.
   static Future<AppPermissionStatus> requestLocation() async {
     final status = await ph.Permission.locationWhenInUse.request();
     return _toStatus(status);
   }
 
-  /// Abre as configuracoes do app no sistema.
+  /// Opens the app settings in the system.
   ///
-  /// Use quando a permissao foi negada permanentemente e o usuario
-  /// precisa habilita-la manualmente.
+  /// Use when the permission was permanently denied and the user
+  /// needs to enable it manually.
   static Future<bool> openSettings() async {
     return await ph.openAppSettings();
   }

--- a/lib/core/theme/app_colors.dart
+++ b/lib/core/theme/app_colors.dart
@@ -1,21 +1,21 @@
 import 'package:flutter/material.dart';
 
-/// Paleta de cores do VisioSoil seguindo Material Design 3
-/// com tons terrosos e verdes remetendo a solo e agricultura.
+/// VisioSoil color palette following Material Design 3
+/// with earthy and green tones evoking soil and agriculture.
 abstract final class AppColors {
-  // Primary - Verde terroso
+  // Primary - Earthy green
   static const Color primary = Color(0xFF4A7C59);
   static const Color onPrimary = Color(0xFFFFFFFF);
   static const Color primaryContainer = Color(0xFFCCE8D4);
   static const Color onPrimaryContainer = Color(0xFF0D2818);
 
-  // Secondary - Marrom terroso
+  // Secondary - Earthy brown
   static const Color secondary = Color(0xFF8B6F47);
   static const Color onSecondary = Color(0xFFFFFFFF);
   static const Color secondaryContainer = Color(0xFFF5E6D3);
   static const Color onSecondaryContainer = Color(0xFF2D1F0E);
 
-  // Tertiary - Verde oliva
+  // Tertiary - Olive green
   static const Color tertiary = Color(0xFF6B7F5A);
   static const Color onTertiary = Color(0xFFFFFFFF);
   static const Color tertiaryContainer = Color(0xFFE4F0D9);
@@ -27,7 +27,7 @@ abstract final class AppColors {
   static const Color errorContainer = Color(0xFFFFDAD6);
   static const Color onErrorContainer = Color(0xFF410002);
 
-  // Warning - Amber terroso
+  // Warning - Earthy amber
   static const Color warning = Color(0xFFC88A3D);
   static const Color warningContainer = Color(0xFFFBEBD2);
 
@@ -63,7 +63,7 @@ abstract final class AppColors {
   static const Color soilClay = Color(0xFF7A4E2D);
   static const Color soilVeryClay = Color(0xFF5B3518);
 
-  /// ColorScheme para uso com ThemeData
+  /// ColorScheme for use with ThemeData
   static ColorScheme get colorScheme => const ColorScheme(
         brightness: Brightness.light,
         primary: primary,

--- a/lib/core/theme/app_radius.dart
+++ b/lib/core/theme/app_radius.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-/// Constantes de border radius para consistência visual.
+/// Border radius constants for visual consistency.
 abstract final class AppRadius {
   /// 8.0
   static const double sm = 8.0;

--- a/lib/core/theme/app_spacing.dart
+++ b/lib/core/theme/app_spacing.dart
@@ -1,4 +1,4 @@
-/// Constantes de espaçamento para layout consistente.
+/// Spacing constants for consistent layout.
 abstract final class AppSpacing {
   /// 4.0
   static const double xs = 4.0;

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -3,7 +3,7 @@ import 'app_colors.dart';
 import 'app_radius.dart';
 import 'app_typography.dart';
 
-/// Tema principal do VisioSoil.
+/// Main VisioSoil theme.
 abstract final class AppTheme {
   /// ThemeData light mode
   static ThemeData get light => ThemeData(

--- a/lib/core/theme/app_typography.dart
+++ b/lib/core/theme/app_typography.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'app_colors.dart';
 
-/// Escala tipográfica do VisioSoil.
+/// VisioSoil typographic scale.
 /// Display/titles: Manrope (bold, tight tracking)
-/// Body/labels: Inter (legível em campo)
+/// Body/labels: Inter (legible in the field)
 ///
 /// Fonts are bundled in assets/fonts/ and registered in pubspec.yaml
 /// via the Flutter fonts: section (no runtime fetching).
@@ -113,7 +113,7 @@ abstract final class AppTypography {
         height: 1.45,
       );
 
-  /// TextTheme para uso com ThemeData
+  /// TextTheme for use with ThemeData
   static TextTheme get textTheme => TextTheme(
         headlineLarge: headlineLarge.copyWith(color: AppColors.onBackground),
         headlineMedium: headlineMedium.copyWith(color: AppColors.onBackground),

--- a/lib/core/utils/formatters.dart
+++ b/lib/core/utils/formatters.dart
@@ -1,12 +1,12 @@
-/// Utilitários de formatação para o app.
+/// Formatting utilities for the app.
 ///
-/// Centraliza funções de formatação para evitar duplicação (DRY).
+/// Centralizes formatting functions to avoid duplication (DRY).
 class Formatters {
   Formatters._();
 
-  /// Formata um timestamp ISO 8601 para exibição.
+  /// Formats an ISO 8601 timestamp for display.
   ///
-  /// Exemplo: "2026-04-01T14:30:00" -> "01/04/2026 às 14:30"
+  /// Example: "2026-04-01T14:30:00" -> "01/04/2026 às 14:30"
   static String timestamp(String isoTimestamp) {
     try {
       final date = DateTime.parse(isoTimestamp);
@@ -20,9 +20,9 @@ class Formatters {
     }
   }
 
-  /// Formata um timestamp ISO 8601 para exibição compacta (sem "às").
+  /// Formats an ISO 8601 timestamp for compact display (without the "às" connector).
   ///
-  /// Exemplo: "2026-04-01T14:30:00" -> "01/04/2026 14:30"
+  /// Example: "2026-04-01T14:30:00" -> "01/04/2026 14:30"
   static String timestampCompact(String isoTimestamp) {
     try {
       final date = DateTime.parse(isoTimestamp);
@@ -36,9 +36,9 @@ class Formatters {
     }
   }
 
-  /// Formata coordenadas GPS para exibição.
+  /// Formats GPS coordinates for display.
   ///
-  /// Exemplo: (-23.550520, -46.633308) -> "-23.550520, -46.633308"
+  /// Example: (-23.550520, -46.633308) -> "-23.550520, -46.633308"
   static String coordinates(double latitude, double longitude) {
     return '${latitude.toStringAsFixed(6)}, ${longitude.toStringAsFixed(6)}';
   }

--- a/lib/core/widgets/empty_state.dart
+++ b/lib/core/widgets/empty_state.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:visiosoil_app/core/theme/app_spacing.dart';
 
-/// Widget para exibir estado vazio em listas.
+/// Widget for displaying an empty state in lists.
 class EmptyState extends StatelessWidget {
   const EmptyState({
     super.key,
@@ -11,16 +11,16 @@ class EmptyState extends StatelessWidget {
     this.action,
   });
 
-  /// Ícone principal.
+  /// Main icon.
   final IconData icon;
 
-  /// Título do estado vazio.
+  /// Empty state title.
   final String title;
 
-  /// Descrição opcional.
+  /// Optional description.
   final String? description;
 
-  /// Widget de ação opcional (ex: botão).
+  /// Optional action widget (e.g. button).
   final Widget? action;
 
   @override

--- a/lib/core/widgets/error_state.dart
+++ b/lib/core/widgets/error_state.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:visiosoil_app/core/theme/app_colors.dart';
 import 'package:visiosoil_app/core/theme/app_spacing.dart';
 
-/// Widget reutilizavel para exibir estado de erro com botao retry.
+/// Reusable widget for displaying an error state with a retry button.
 class ErrorState extends StatelessWidget {
   const ErrorState({
     super.key,

--- a/lib/core/widgets/loading_indicator.dart
+++ b/lib/core/widgets/loading_indicator.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-/// Indicador de loading padronizado do VisioSoil.
+/// Standardized VisioSoil loading indicator.
 class LoadingIndicator extends StatelessWidget {
   const LoadingIndicator({
     super.key,
@@ -9,13 +9,13 @@ class LoadingIndicator extends StatelessWidget {
     this.color,
   });
 
-  /// Tamanho do indicador. Padrão: 40.
+  /// Indicator size. Default: 40.
   final double size;
 
-  /// Espessura do traço. Padrão: 3.
+  /// Stroke width. Default: 3.
   final double strokeWidth;
 
-  /// Cor do indicador. Usa primary se não especificado.
+  /// Indicator color. Uses primary if not specified.
   final Color? color;
 
   @override

--- a/lib/core/widgets/permission_denied_view.dart
+++ b/lib/core/widgets/permission_denied_view.dart
@@ -3,10 +3,10 @@ import 'package:visiosoil_app/core/services/permission_service.dart';
 import 'package:visiosoil_app/core/theme/app_colors.dart';
 import 'package:visiosoil_app/core/theme/app_spacing.dart';
 
-/// Widget reutilizavel para exibir estado de permissao negada.
+/// Reusable widget for displaying a permission denied state.
 ///
-/// Mostra icone, titulo, descricao e botao para abrir configuracoes
-/// quando a permissao foi negada permanentemente.
+/// Shows icon, title, description, and a button to open settings
+/// when the permission was permanently denied.
 class PermissionDeniedView extends StatelessWidget {
   const PermissionDeniedView({
     super.key,
@@ -17,21 +17,21 @@ class PermissionDeniedView extends StatelessWidget {
     this.onRetry,
   });
 
-  /// Icone representando a permissao (ex: Icons.camera_alt).
+  /// Icon representing the permission (e.g. Icons.camera_alt).
   final IconData icon;
 
-  /// Titulo do estado de permissao negada.
+  /// Title of the permission denied state.
   final String title;
 
-  /// Descricao explicando por que a permissao e necessaria.
+  /// Description explaining why the permission is needed.
   final String description;
 
-  /// Se true, mostra botao para abrir configuracoes do sistema.
-  /// Se false, mostra botao para tentar novamente.
+  /// If true, shows a button to open the system settings.
+  /// If false, shows a button to try again.
   final bool isPermanentlyDenied;
 
-  /// Callback quando o usuario toca em "Tentar novamente".
-  /// Ignorado se [isPermanentlyDenied] for true.
+  /// Callback for when the user taps "Tentar novamente".
+  /// Ignored if [isPermanentlyDenied] is true.
   final VoidCallback? onRetry;
 
   @override

--- a/lib/core/widgets/visio_app_bar.dart
+++ b/lib/core/widgets/visio_app_bar.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-/// AppBar padronizada do VisioSoil.
+/// Standardized VisioSoil AppBar.
 class VisioAppBar extends StatelessWidget implements PreferredSizeWidget {
   const VisioAppBar({
     super.key,
@@ -14,19 +14,19 @@ class VisioAppBar extends StatelessWidget implements PreferredSizeWidget {
           'Não é possível usar title e titleWidget ao mesmo tempo',
         );
 
-  /// Título como String.
+  /// Title as a String.
   final String? title;
 
-  /// Título como Widget customizado.
+  /// Title as a custom Widget.
   final Widget? titleWidget;
 
-  /// Widget à esquerda (ex: botão voltar).
+  /// Widget on the left (e.g. back button).
   final Widget? leading;
 
-  /// Widgets à direita.
+  /// Widgets on the right.
   final List<Widget>? actions;
 
-  /// Centralizar título. Padrão: true.
+  /// Whether to center the title. Default: true.
   final bool centerTitle;
 
   @override

--- a/lib/core/widgets/visio_button.dart
+++ b/lib/core/widgets/visio_button.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 
-/// Variantes do VisioButton.
+/// VisioButton variants.
 enum VisioButtonVariant { primary, secondary }
 
-/// Botão padronizado do VisioSoil.
+/// Standardized VisioSoil button.
 class VisioButton extends StatelessWidget {
   const VisioButton({
     super.key,
@@ -15,22 +15,22 @@ class VisioButton extends StatelessWidget {
     this.expanded = false,
   });
 
-  /// Texto do botão.
+  /// Button text.
   final String label;
 
-  /// Callback ao pressionar.
+  /// Callback when pressed.
   final VoidCallback? onPressed;
 
-  /// Ícone opcional à esquerda do label.
+  /// Optional icon to the left of the label.
   final IconData? icon;
 
-  /// Se true, mostra loading indicator em vez do conteúdo.
+  /// If true, shows a loading indicator instead of the content.
   final bool isLoading;
 
-  /// Variante visual: primary (filled) ou secondary (outlined).
+  /// Visual variant: primary (filled) or secondary (outlined).
   final VisioButtonVariant variant;
 
-  /// Se true, expande para ocupar toda a largura disponível.
+  /// If true, expands to fill all available width.
   final bool expanded;
 
   @override

--- a/lib/models/capture_context.dart
+++ b/lib/models/capture_context.dart
@@ -1,7 +1,7 @@
-/// Contexto de captura com informações de cultura, época e profundidade.
+/// Capture context with crop, season, and depth information.
 ///
-/// Usado para associar metadados à análise de solo antes da captura.
-/// Todos os campos são opcionais para permitir flexibilidade no fluxo.
+/// Used to attach metadata to the soil analysis before capture.
+/// All fields are optional to allow flexibility in the flow.
 class CaptureContext {
   final Crop? crop;
   final PlantingSeason? plantingSeason;
@@ -25,11 +25,11 @@ class CaptureContext {
     );
   }
 
-  /// Verifica se o contexto está completo para captura.
+  /// Checks whether the context is complete for capture.
   bool get isComplete =>
       crop != null && plantingSeason != null && samplingDepth != null;
 
-  /// Retorna um resumo do contexto para exibição.
+  /// Returns a summary of the context for display.
   String get summary {
     final parts = <String>[];
     if (crop != null) parts.add(crop!.name);
@@ -38,7 +38,7 @@ class CaptureContext {
   }
 }
 
-/// Representa uma cultura agrícola.
+/// Represents an agricultural crop.
 class Crop {
   final String id;
   final String name;
@@ -50,7 +50,7 @@ class Crop {
     required this.iconCodePoint,
   });
 
-  /// Culturas disponíveis com ícones Material Design.
+  /// Available crops with Material Design icons.
   static const List<Crop> available = [
     Crop(id: 'soy', name: 'Soja', iconCodePoint: 'grass'),
     Crop(id: 'corn', name: 'Milho', iconCodePoint: 'grain'),
@@ -61,7 +61,7 @@ class Crop {
   ];
 }
 
-/// Época de plantio da cultura.
+/// Planting season of the crop.
 enum PlantingSeason {
   safra('Safra', 'Plantio principal'),
   safrinha('Safrinha', 'Segunda safra'),
@@ -73,7 +73,7 @@ enum PlantingSeason {
   const PlantingSeason(this.label, this.description);
 }
 
-/// Profundidade de amostragem do solo.
+/// Soil sampling depth.
 enum SamplingDepth {
   shallow(0, 20, '0-20 cm', 'Camada superficial'),
   medium(20, 40, '20-40 cm', 'Camada intermediária'),

--- a/lib/models/confidence_level.dart
+++ b/lib/models/confidence_level.dart
@@ -1,22 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:visiosoil_app/core/theme/app_colors.dart';
 
-/// Faixas de confiança para classificação de textura.
+/// Confidence ranges for texture classification.
 ///
-/// Thresholds centralizados: alta >= 80%, moderada 60-79%, baixa < 60%.
+/// Centralized thresholds: high >= 80%, moderate 60-79%, low < 60%.
 enum ConfidenceLevel {
   high,
   moderate,
   low;
 
-  /// Threshold inferior da faixa alta (0.80).
+  /// Lower threshold of the high range (0.80).
   static const double highThreshold = 0.80;
 
-  /// Threshold inferior da faixa moderada (0.60).
+  /// Lower threshold of the moderate range (0.60).
   static const double moderateThreshold = 0.60;
 
-  /// Determina o nível de confiança a partir do score (0.0 a 1.0).
-  /// Retorna [low] para valores nulos ou NaN.
+  /// Determines the confidence level from the score (0.0 to 1.0).
+  /// Returns [low] for null or NaN values.
   factory ConfidenceLevel.fromScore(double? score) {
     if (score == null || score.isNaN) return ConfidenceLevel.low;
     if (score >= highThreshold) return ConfidenceLevel.high;
@@ -24,28 +24,28 @@ enum ConfidenceLevel {
     return ConfidenceLevel.low;
   }
 
-  /// Label localizado para exibição.
+  /// Localized label for display.
   String get label => switch (this) {
         ConfidenceLevel.high => 'Alta',
         ConfidenceLevel.moderate => 'Moderada',
         ConfidenceLevel.low => 'Baixa',
       };
 
-  /// Cor de fundo do badge.
+  /// Badge background color.
   Color get backgroundColor => switch (this) {
         ConfidenceLevel.high => AppColors.primaryContainer,
         ConfidenceLevel.moderate => AppColors.warningContainer,
         ConfidenceLevel.low => AppColors.errorContainer,
       };
 
-  /// Cor do texto/ícone do badge.
+  /// Badge text/icon color.
   Color get foregroundColor => switch (this) {
         ConfidenceLevel.high => AppColors.onPrimaryContainer,
         ConfidenceLevel.moderate => const Color(0xFF6D4C1D),
         ConfidenceLevel.low => AppColors.onErrorContainer,
       };
 
-  /// Ícone representativo do nível.
+  /// Icon representing the level.
   IconData get icon => switch (this) {
         ConfidenceLevel.high => Icons.verified,
         ConfidenceLevel.moderate => Icons.info_outline,

--- a/lib/models/home_stats.dart
+++ b/lib/models/home_stats.dart
@@ -1,4 +1,4 @@
-/// Dados agregados para exibicao na HomeScreen.
+/// Aggregated data for display on the HomeScreen.
 class HomeStats {
   const HomeStats({
     required this.totalRecords,
@@ -6,16 +6,16 @@ class HomeStats {
     required this.averageConfidence,
   });
 
-  /// Total de registros no banco.
+  /// Total number of records in the database.
   final int totalRecords;
 
-  /// Quantidade de enderecos distintos.
+  /// Number of distinct addresses.
   final int distinctLocations;
 
-  /// Media de confianca (0.0 a 1.0) ou null se nenhum registro com score.
+  /// Average confidence (0.0 to 1.0) or null if no record has a score.
   final double? averageConfidence;
 
-  /// Media formatada como porcentagem, ou '-' se nao disponivel.
+  /// Average formatted as a percentage, or '-' if not available.
   String get formattedConfidence => averageConfidence == null
       ? '-'
       : '${(averageConfidence! * 100).round()}%';

--- a/lib/models/soil_record.dart
+++ b/lib/models/soil_record.dart
@@ -1,9 +1,9 @@
 import 'package:visiosoil_app/core/utils/formatters.dart';
 
-/// Registro de amostra de solo (modelo de domínio).
+/// Soil sample record (domain model).
 ///
-/// O [id] é nulo antes da persistência e preenchido pelo repositório após
-/// a inserção no banco de dados.
+/// The [id] is null before persistence and filled in by the repository after
+/// the insertion into the database.
 class SoilRecord {
   final int? id;
   final String imagePath;
@@ -25,7 +25,7 @@ class SoilRecord {
     this.confidenceScore,
   });
 
-  /// Retorna uma cópia deste registro com os campos informados substituídos.
+  /// Returns a copy of this record with the given fields replaced.
   SoilRecord copyWith({
     int? id,
     String? imagePath,
@@ -48,40 +48,40 @@ class SoilRecord {
     );
   }
 
-  /// Indica se o registro possui coordenadas GPS válidas.
+  /// Indicates whether the record has valid GPS coordinates.
   bool get hasCoordinates => latitude != null && longitude != null;
 
-  /// Indica se o registro possui um endereço válido.
+  /// Indicates whether the record has a valid address.
   bool get hasValidAddress =>
       address != null &&
       address!.isNotEmpty &&
       address != 'Localização não disponível' &&
       address != 'Localização não informada';
 
-  /// Retorna o timestamp formatado para exibição.
+  /// Returns the timestamp formatted for display.
   String get formattedTimestamp => Formatters.timestamp(timestamp);
 
-  /// Retorna o timestamp formatado de forma compacta.
+  /// Returns the timestamp formatted in compact form.
   String get formattedTimestampCompact =>
       Formatters.timestampCompact(timestamp);
 
-  /// Retorna as coordenadas formatadas.
+  /// Returns the formatted coordinates.
   String get formattedCoordinates => hasCoordinates
       ? Formatters.coordinates(latitude!, longitude!)
       : 'Coordenadas não disponíveis';
 
-  /// Retorna o endereço ou uma mensagem padrão.
+  /// Returns the address or a default message.
   String get displayAddress =>
       hasValidAddress ? address! : 'Endereço não disponível';
 
-  /// Indica se o registro possui classificação de textura.
+  /// Indicates whether the record has a texture classification.
   bool get hasClassification => textureClass != null && textureClass!.isNotEmpty;
 
-  /// Retorna a classe de textura ou uma mensagem padrão.
+  /// Returns the texture class or a default message.
   String get displayTextureClass =>
       hasClassification ? textureClass! : 'Não classificado';
 
-  /// Retorna o score de confiança formatado como porcentagem.
+  /// Returns the confidence score formatted as a percentage.
   String get formattedConfidence => confidenceScore != null
       ? '${(confidenceScore! * 100).toStringAsFixed(1)}%'
       : '-';

--- a/lib/providers/database_provider.dart
+++ b/lib/providers/database_provider.dart
@@ -1,8 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:visiosoil_app/core/database/app_database.dart';
 
-/// Fornece uma instância singleton de [AppDatabase] enquanto o [ProviderScope]
-/// estiver vivo. O banco é fechado automaticamente no descarte do provider.
+/// Provides a singleton [AppDatabase] instance while the [ProviderScope]
+/// is alive. The database is closed automatically when the provider is disposed.
 final appDatabaseProvider = Provider<AppDatabase>((ref) {
   final db = AppDatabase();
   ref.onDispose(db.close);

--- a/lib/providers/inference_provider.dart
+++ b/lib/providers/inference_provider.dart
@@ -1,11 +1,11 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:visiosoil_app/core/services/inference_service.dart';
 
-/// Provider singleton para o [InferenceService].
+/// Singleton provider for the [InferenceService].
 ///
-/// O serviço é criado sob demanda e descartado quando o [ProviderScope] é
-/// destruído. A inicialização (carregamento do modelo) é lazy — ocorre na
-/// primeira chamada a [InferenceService.classify].
+/// The service is created on demand and discarded when the [ProviderScope] is
+/// destroyed. Initialization (model loading) is lazy — it happens on the
+/// first call to [InferenceService.classify].
 final inferenceServiceProvider = Provider<InferenceService>((ref) {
   final service = InferenceService();
   ref.onDispose(service.dispose);

--- a/lib/providers/soil_record_repository_provider.dart
+++ b/lib/providers/soil_record_repository_provider.dart
@@ -5,36 +5,36 @@ import 'package:visiosoil_app/models/home_stats.dart';
 import 'package:visiosoil_app/models/soil_record.dart';
 import 'package:visiosoil_app/providers/database_provider.dart';
 
-/// Expõe o repositório **pela interface** [SoilRecordRepository]. As telas
-/// nunca devem ler diretamente [DriftSoilRecordRepository].
+/// Exposes the repository **through the interface** [SoilRecordRepository]. Screens
+/// must never read [DriftSoilRecordRepository] directly.
 final soilRecordRepositoryProvider = Provider<SoilRecordRepository>((ref) {
   return DriftSoilRecordRepository(ref.watch(appDatabaseProvider));
 });
 
-/// Stream reativa com todos os registros, do mais recente ao mais antigo.
+/// Reactive stream with all records, from most recent to oldest.
 final soilRecordsStreamProvider = StreamProvider<List<SoilRecord>>((ref) {
   return ref.watch(soilRecordRepositoryProvider).watchAll();
 });
 
-/// Último registro (ou `null` se não houver nenhum).
+/// Latest record (or `null` if there is none).
 ///
-/// Derivado da [soilRecordsStreamProvider] para aproveitar o mesmo stream e
-/// reaproveitar o cache do Riverpod, evitando consultas duplicadas.
+/// Derived from [soilRecordsStreamProvider] to share the same stream and
+/// reuse the Riverpod cache, avoiding duplicate queries.
 final latestSoilRecordProvider = Provider<AsyncValue<SoilRecord?>>((ref) {
   final records = ref.watch(soilRecordsStreamProvider);
   return records.whenData((list) => list.isEmpty ? null : list.first);
 });
 
-/// Carrega um registro por id. `family` permite obter o provider específico
-/// para o id desejado — o Riverpod cuida do cache.
+/// Loads a record by id. `family` allows obtaining the specific provider
+/// for the desired id — Riverpod takes care of the cache.
 final soilRecordByIdProvider =
     FutureProvider.family<SoilRecord?, int>((ref, id) {
   return ref.watch(soilRecordRepositoryProvider).getById(id);
 });
 
-/// Dados agregados para a HomeScreen, derivados do stream reativo.
+/// Aggregated data for the HomeScreen, derived from the reactive stream.
 ///
-/// Atualiza automaticamente ao salvar/deletar registros.
+/// Updates automatically when records are saved/deleted.
 final homeStatsProvider = Provider<AsyncValue<HomeStats>>((ref) {
   final records = ref.watch(soilRecordsStreamProvider);
   return records.whenData((list) {
@@ -56,9 +56,9 @@ final homeStatsProvider = Provider<AsyncValue<HomeStats>>((ref) {
   });
 });
 
-// --- Filtros do Historico ---
+// --- History Filters ---
 
-/// Notifier para filtro de classe de textura.
+/// Notifier for the texture class filter.
 class SelectedTextureFilterNotifier extends Notifier<String?> {
   @override
   String? build() => null;
@@ -66,12 +66,12 @@ class SelectedTextureFilterNotifier extends Notifier<String?> {
   void select(String? textureClass) => state = textureClass;
 }
 
-/// Filtro de classe de textura selecionado (null = todas).
+/// Selected texture class filter (null = all).
 final selectedTextureFilterProvider =
     NotifierProvider<SelectedTextureFilterNotifier, String?>(
         SelectedTextureFilterNotifier.new);
 
-/// Notifier para termo de busca.
+/// Notifier for the search term.
 class SearchTermNotifier extends Notifier<String> {
   @override
   String build() => '';
@@ -79,24 +79,24 @@ class SearchTermNotifier extends Notifier<String> {
   void update(String term) => state = term;
 }
 
-/// Termo de busca por endereco.
+/// Address search term.
 final searchTermProvider =
     NotifierProvider<SearchTermNotifier, String>(SearchTermNotifier.new);
 
-/// Classes de textura disponiveis para filtro.
+/// Texture classes available for filtering.
 final availableTextureClassesProvider = FutureProvider<List<String>>((ref) {
   return ref.watch(soilRecordRepositoryProvider).getDistinctTextureClasses();
 });
 
-/// Stream de registros filtrados.
+/// Stream of filtered records.
 ///
-/// Combina filtro de classe e termo de busca. Atualiza automaticamente
-/// quando qualquer filtro muda ou quando o banco e modificado.
+/// Combines class filter and search term. Updates automatically
+/// when any filter changes or when the database is modified.
 final filteredRecordsProvider = StreamProvider<List<SoilRecord>>((ref) {
   final textureClass = ref.watch(selectedTextureFilterProvider);
   final searchTerm = ref.watch(searchTermProvider);
 
-  // Se nenhum filtro ativo, usa stream normal para performance
+  // If no filter is active, uses the regular stream for performance
   if ((textureClass == null || textureClass.isEmpty) &&
       searchTerm.isEmpty) {
     return ref.watch(soilRecordRepositoryProvider).watchAll();

--- a/test/repositories/drift_soil_record_repository_test.dart
+++ b/test/repositories/drift_soil_record_repository_test.dart
@@ -1,9 +1,9 @@
-// Testes de [DriftSoilRecordRepository] usando um banco SQLite em memória.
+// Tests for [DriftSoilRecordRepository] using an in-memory SQLite database.
 //
-// Executa no Dart VM (sem device) — `NativeDatabase.memory()` precisa da
-// biblioteca nativa do SQLite. No CI (Linux/macOS/Windows) isso funciona de
-// fábrica porque `sqlite3_flutter_libs` distribui a shared library; em hosts
-// sem SQLite no PATH pode ser necessário instalar o pacote `sqlite3` do SO.
+// Runs on the Dart VM (no device) — `NativeDatabase.memory()` needs the
+// native SQLite library. On CI (Linux/macOS/Windows) this works out of the
+// box because `sqlite3_flutter_libs` ships the shared library; on hosts
+// without SQLite on the PATH, installing the OS `sqlite3` package may be required.
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:visiosoil_app/core/data/repositories/drift_soil_record_repository.dart';
@@ -135,7 +135,7 @@ void main() {
       final emissions = <List<SoilRecord>>[];
       final sub = stream.listen(emissions.add);
 
-      // Aguarda a primeira emissão (lista vazia).
+      // Waits for the first emission (empty list).
       await Future<void>.delayed(const Duration(milliseconds: 50));
       final inserted = await repo.create(sample());
       await Future<void>.delayed(const Duration(milliseconds: 50));


### PR DESCRIPTION
## 1. Context

**Motivation:** 267 comment lines across 34 Dart files in `lib/` and `test/` were written in Portuguese, violating the Language rule of `code_conventions.md` and the project's own `CLAUDE.md` convention that code comments are English. This was the largest divergence found by the my-framework adoption review (PR #39).

**Task Link:** none (no tracker in use).

**Spec Link:** [docs/specs/SPEC-english-doc-comments.md](https://github.com/LukeSantossz/visiosoil-app/blob/docs/english-doc-comments/docs/specs/SPEC-english-doc-comments.md) — approved at the Spec Gate.

## 2. What Was Done

- Translated every Portuguese comment (`///` dartdoc and `//` inline) in `lib/` and `test/` to technical English: 34 files, 267 lines replaced in place (insertions = deletions — no line added, removed, or moved).
- String literals (pt-BR product copy), identifiers, and executable code are byte-identical: a mechanical check over the diff confirms every changed line begins with a comment marker.
- Dartdoc structure preserved verbatim: `[SymbolReferences]`, backtick code spans, formatting, indentation, and comment placement.
- One documented exception: the dartdoc examples in `lib/core/utils/formatters.dart` quote the formatter's literal pt-BR output (`"01/04/2026 às 14:30"`) — that is data, not Portuguese prose, and the spec's acceptance criterion records the exemption.
- The sweep covered 10 files beyond the original accent-based list (accent-free Portuguese comments in screens, theme, and widget files).

## 3. How to Test

1. Check out the branch: `git checkout docs/english-doc-comments`
2. `grep -rEn --include='*.dart' '//.*[áéíóúâêôãõç]' lib test | grep -v 'formatters.dart'` → zero matches.
3. `git diff main...HEAD -- lib test | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vcE '^[+-]\s*///?'` → 0 (only comment lines changed).
4. `flutter pub get && dart run build_runner build --delete-conflicting-outputs && flutter analyze && flutter test` — results identical to `main`, since comments cannot change semantics.

## 4. Evidence

Omitted: comment-only change with no visual surface (per template rule).

## 5. Self-Review Checklist

- [x] Self-review done: the full 34-file diff was reviewed line by line against the originals before this PR; human Review Again (CRURA RA stage) pending in the Files Changed tab before merge.
- [x] Spec approved at the Gate before implementation, and the change matches its Scope (per `spec_method.md`).
- [x] Acceptance criteria verified by command: zero accented comment lines outside the documented `formatters.dart` exemption; zero non-comment lines in the dart diff; UI strings byte-identical. Test-first does not apply: comment-only change with no production code; CI on this PR confirms analyzer/test parity with `main`.
- [x] Commented-out code and unnecessary debug statements removed: none introduced; pre-existing stale dartdoc reference in `processing_screen.dart` (`[onComplete]`) was translated faithfully, not silently "fixed" — left for its own change.
- [x] Code follows the project style guide: no code changed.
- [x] New dependencies work without breaking the build: none added.
- [x] Review layers recorded: **R1** — the translation was authored by a Claude subagent under hard constraints and reviewed in full by the session author (line-by-line diff read plus independent mechanical verification); one finding from that review was fixed before this PR (a quoted output sample had been re-encoded as `às` to satisfy the sweep — reverted to quote the real output, with the exemption documented in the spec). **R2** — not run: no second-provider reviewer is configured; per `ai_guidelines.md` Review Composition, R1 plus the human PR review stand in, recorded here. **R3** — CodeRabbit, runs automatically on this PR. Author model: Claude subagent (Anthropic); Reviewer: Claude session author (same provider, hence R2 remains absent).

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9DkdzAbbXkJ5UAuBqKxhp)_