### PR TITLE
fix(location): align stored address sentinel with validity check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,4 +116,3 @@ GitHub Actions (`.github/workflows/ci.yml`) runs on push/PR to `main` or `dev`:
 - `/capture/setup` wizard is orphaned: no screen navigates to it, the `/capture` route ignores `state.extra`, and `soil_records` (v2) has no columns for crop/season/depth — either persist `CaptureContext` (schema v3) or remove the wizard
 - `/processing` and `/result` routes are registered but have no callers in the UI — integrate or remove
 - Labels and preprocessing are hardcoded in `InferenceService` — `spec.json` is not read at runtime
-- Address sentinel mismatch: capture saves `'Localizacao nao disponivel'` (unaccented) but `SoilRecord.hasValidAddress` checks accented variants — align the strings

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -1,0 +1,7 @@
+/// Shared string constants used across more than one layer.
+abstract final class AppStrings {
+  /// Stored when a record has no usable address. Shared by the writers that
+  /// persist it and by `SoilRecord.hasValidAddress` so the stored value and the
+  /// validity check can never drift apart (the cause of the prior sentinel bug).
+  static const String addressUnavailable = 'Localização não disponível';
+}

--- a/lib/core/features/capture/capture_screen.dart
+++ b/lib/core/features/capture/capture_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:visiosoil_app/core/constants/app_strings.dart';
 import 'package:visiosoil_app/core/services/inference_service.dart';
 import 'package:visiosoil_app/core/services/permission_service.dart';
 import 'package:visiosoil_app/core/theme/app_spacing.dart';
@@ -161,8 +162,7 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen>
     setState(() => _isSaving = true);
 
     try {
-      final String finalAddress =
-          _address ?? 'Localizacao nao disponivel';
+      final String finalAddress = _address ?? AppStrings.addressUnavailable;
       final double? finalLatitude = _latitude;
       final double? finalLongitude = _longitude;
 

--- a/lib/core/utils/location_service.dart
+++ b/lib/core/utils/location_service.dart
@@ -1,5 +1,6 @@
 import 'package:geolocator/geolocator.dart';
 import 'package:geocoding/geocoding.dart';
+import 'package:visiosoil_app/core/constants/app_strings.dart';
 
 class LocationService {
   static Future<Position> getCurrentLocation() async {
@@ -31,7 +32,7 @@ class LocationService {
       position.latitude,
       position.longitude,
     );
-    if (placemarks.isEmpty) return 'Endereço não disponível ou mapeado';
+    if (placemarks.isEmpty) return AppStrings.addressUnavailable;
     Placemark placemark = placemarks[0];
     return '${placemark.street}, ${placemark.locality}, ${placemark.administrativeArea}';
   }

--- a/lib/models/soil_record.dart
+++ b/lib/models/soil_record.dart
@@ -1,3 +1,4 @@
+import 'package:visiosoil_app/core/constants/app_strings.dart';
 import 'package:visiosoil_app/core/utils/formatters.dart';
 
 /// Soil sample record (domain model).
@@ -55,8 +56,7 @@ class SoilRecord {
   bool get hasValidAddress =>
       address != null &&
       address!.isNotEmpty &&
-      address != 'Localização não disponível' &&
-      address != 'Localização não informada';
+      address != AppStrings.addressUnavailable;
 
   /// Returns the timestamp formatted for display.
   String get formattedTimestamp => Formatters.timestamp(timestamp);

--- a/test/soil_record_test.dart
+++ b/test/soil_record_test.dart
@@ -31,7 +31,7 @@ void main() {
       final noAddr = SoilRecord(imagePath: '/d.jpg', timestamp: ts);
       final placeholder = SoilRecord(
         imagePath: '/e.jpg',
-        address: 'Localização não disponível',
+        address: AppStrings.addressUnavailable,
         timestamp: ts,
       );
       expect(noAddr.hasValidAddress, isFalse);
@@ -45,6 +45,8 @@ void main() {
         timestamp: ts,
       );
       expect(r.hasValidAddress, isFalse);
+      // The stored sentinel must never leak to the UI as a real address.
+      expect(r.displayAddress, isNot(AppStrings.addressUnavailable));
     });
 
     test('hasClassification is false when textureClass is null or empty', () {

--- a/test/soil_record_test.dart
+++ b/test/soil_record_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:visiosoil_app/core/constants/app_strings.dart';
 import 'package:visiosoil_app/models/soil_record.dart';
 
 void main() {
@@ -35,6 +36,15 @@ void main() {
       );
       expect(noAddr.hasValidAddress, isFalse);
       expect(placeholder.hasValidAddress, isFalse);
+    });
+
+    test('hasValidAddress rejects the shared unavailable sentinel', () {
+      final r = SoilRecord(
+        imagePath: '/i.jpg',
+        address: AppStrings.addressUnavailable,
+        timestamp: ts,
+      );
+      expect(r.hasValidAddress, isFalse);
     });
 
     test('hasClassification is false when textureClass is null or empty', () {


### PR DESCRIPTION
## 1. Context

- **Motivation:** A record saved with no usable address stored an unaccented sentinel (`'Localizacao nao disponivel'`) that `SoilRecord.hasValidAddress` — which only checked accented variants — treated as a real address, so the placeholder leaked into the UI. A second writer (`LocationService`) stored yet another distinct string with the same effect.
- **Task Link:** none (no tracker in use)
- **Spec Link:** embedded below — specs are ephemeral Spec Gate artifacts in this project and are not committed.

<details><summary>Approved SPEC (Spec Gate)</summary>

### Problem
A no-address record stores a sentinel string that `hasValidAddress` fails to recognize, so the placeholder is treated as a valid address.

### Design Decision
Introduce a single canonical constant `AppStrings.addressUnavailable`, referenced by both writers (capture flow and geocoding fallback) and by `hasValidAddress`, so the stored value and the validity check cannot drift apart. Follows the project's `abstract final class` + `static const` constants pattern (`AppSpacing`, `AppRadius`).

### Alternatives Considered
- Add the unaccented string to the check's reject list — rejected: patches the symptom, leaves three divergent literals and the magic-string smell.
- Normalize/strip accents at comparison time — rejected: hides intent, heavier, and still leaves the writers producing inconsistent strings.

### Scope
- Includes: shared constant; wiring of `hasValidAddress`, `CaptureScreen`, and `LocationService`; removal of the dead `'Localização não informada'` variant; a regression test; debt-item removal from `CLAUDE.md`.
- Does NOT include: routing display-only UI fallbacks (details/preview screens) through the constant; any DB migration; the orphaned-routes or `spec.json` debt items (separate changes).

### Acceptance Criteria
- `hasValidAddress` returns false for `AppStrings.addressUnavailable`.
- The stored sentinel does not leak through `displayAddress`.
- `flutter analyze` and `flutter test` are green.

</details>

## 2. What Was Done

- Added `lib/core/constants/app_strings.dart` with `AppStrings.addressUnavailable`.
- Pointed `SoilRecord.hasValidAddress`, `CaptureScreen._saveRecord`, and `LocationService.getAddressFromPosition` at the shared constant; removed the dead `'Localização não informada'` check.
- Added a regression test in `test/soil_record_test.dart` (written before the fix) and updated the existing placeholder test to use the constant.
- Removed the resolved sentinel item from the `CLAUDE.md` Known Technical Debt list.

## 3. How to Test

1. Check out the branch.
2. Install dependencies: `flutter pub get`.
3. Run the checks: `flutter analyze && flutter test`.
4. Verify the build runs without errors.

## 5. Self-Review Checklist

- [x] Self-review done in the Files Changed tab.
- [x] Spec approved at the Gate before implementation (via the approved plan), and the change matches its Scope.
- [x] Each Acceptance Criterion has a passing test; the test was written before its implementation (red commit precedes the green commit).
- [x] Commented-out code and unnecessary debug statements removed.
- [x] Code follows the project style guide (`flutter analyze` clean).
- [x] New dependencies work without breaking the build — no new dependencies added.
- [x] Review layers recorded: R1 internal self-review done; R2 cross-provider review did not run (no second-provider reviewer configured) — R1 plus the human PR review stand in for it; R3 CodeRabbit runs on this PR. Author model: Claude Opus 4.8.