### PR TITLE
fix(history): derive texture filter classes from records stream

### DIFF
--- a/lib/providers/soil_record_repository_provider.dart
+++ b/lib/providers/soil_record_repository_provider.dart
@@ -83,9 +83,23 @@ class SearchTermNotifier extends Notifier<String> {
 final searchTermProvider =
     NotifierProvider<SearchTermNotifier, String>(SearchTermNotifier.new);
 
-/// Texture classes available for filtering.
-final availableTextureClassesProvider = FutureProvider<List<String>>((ref) {
-  return ref.watch(soilRecordRepositoryProvider).getDistinctTextureClasses();
+/// Distinct texture classes for the history filter, derived reactively from
+/// the records stream so chips refresh as records are added or removed.
+///
+/// Mirrors [latestSoilRecordProvider]/[homeStatsProvider]: shares the single
+/// [soilRecordsStreamProvider] subscription instead of a one-shot query that
+/// would never refresh.
+final availableTextureClassesProvider =
+    Provider<AsyncValue<List<String>>>((ref) {
+  final records = ref.watch(soilRecordsStreamProvider);
+  return records.whenData((list) {
+    final classes = <String>{
+      for (final record in list)
+        if (record.hasClassification) record.textureClass!,
+    }.toList()
+      ..sort();
+    return classes;
+  });
 });
 
 /// Stream of filtered records.

--- a/test/providers/available_texture_classes_provider_test.dart
+++ b/test/providers/available_texture_classes_provider_test.dart
@@ -1,0 +1,95 @@
+// Tests for [availableTextureClassesProvider]: the history texture-filter chip
+// source must reflect database changes reactively, not a one-shot snapshot.
+//
+// Runs on the Dart VM with an in-memory SQLite database, the same setup as the
+// repository tests.
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:visiosoil_app/core/database/app_database.dart';
+import 'package:visiosoil_app/models/soil_record.dart';
+import 'package:visiosoil_app/providers/database_provider.dart';
+import 'package:visiosoil_app/providers/soil_record_repository_provider.dart';
+
+void main() {
+  group('availableTextureClassesProvider', () {
+    late AppDatabase db;
+    late ProviderContainer container;
+
+    String ts() => DateTime.utc(2026, 1, 1).toIso8601String();
+
+    SoilRecord sample({String? textureClass, String imagePath = '/img.jpg'}) {
+      return SoilRecord(
+        imagePath: imagePath,
+        timestamp: ts(),
+        textureClass: textureClass,
+        confidenceScore: textureClass == null ? null : 0.9,
+      );
+    }
+
+    // Lets the Drift watch() stream emit and the derived provider recompute,
+    // mirroring the delay used in the repository stream tests.
+    Future<void> settle() =>
+        Future<void>.delayed(const Duration(milliseconds: 50));
+
+    List<String> classes() =>
+        container.read(availableTextureClassesProvider).value ?? const [];
+
+    setUp(() {
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      container = ProviderContainer(
+        overrides: [appDatabaseProvider.overrideWithValue(db)],
+      );
+      addTearDown(container.dispose);
+      // Keep the provider and its underlying stream subscription alive.
+      final sub = container.listen(availableTextureClassesProvider, (_, _) {});
+      addTearDown(sub.close);
+    });
+
+    test('is empty when there are no records', () async {
+      await settle();
+      expect(classes(), isEmpty);
+    });
+
+    test('adds a class reactively when a new classified record is created',
+        () async {
+      await settle();
+      expect(classes(), isEmpty);
+
+      await container
+          .read(soilRecordRepositoryProvider)
+          .create(sample(textureClass: 'Arenosa', imagePath: '/a.jpg'));
+      await settle();
+
+      expect(classes(), contains('Arenosa'));
+    });
+
+    test('returns distinct, sorted classes and ignores unclassified records',
+        () async {
+      await settle();
+      final repo = container.read(soilRecordRepositoryProvider);
+      await repo.create(sample(textureClass: 'Arenosa', imagePath: '/a.jpg'));
+      await repo.create(sample(textureClass: 'Argilosa', imagePath: '/b.jpg'));
+      await repo.create(sample(textureClass: 'Arenosa', imagePath: '/c.jpg'));
+      await repo.create(sample(imagePath: '/d.jpg')); // unclassified
+      await settle();
+
+      expect(classes(), ['Arenosa', 'Argilosa']);
+    });
+
+    test('removes a class when its last record is deleted', () async {
+      await settle();
+      final repo = container.read(soilRecordRepositoryProvider);
+      final saved = await repo
+          .create(sample(textureClass: 'Arenosa', imagePath: '/a.jpg'));
+      await settle();
+      expect(classes(), contains('Arenosa'));
+
+      await repo.deleteById(saved.id!);
+      await settle();
+
+      expect(classes(), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## 1. Context
- **Motivation:** The history texture-filter chips were sourced from a one-shot `FutureProvider` that never refreshed, so chips could omit valid classes — most visibly, a user's first classified capture produced no chips until an app restart.
- **Task Link:** N/A
- **Spec Link:** Spec embedded below (ephemeral — not committed to `main`, per project policy).

## 2. What Was Done
- Reworked `availableTextureClassesProvider` from `FutureProvider<List<String>>` into a `Provider<AsyncValue<List<String>>>` derived from the existing `soilRecordsStreamProvider` (same pattern as `latestSoilRecordProvider` / `homeStatsProvider`).
- Result is de-duplicated, alphabetically sorted, and ignores unclassified records.
- No repository or consumer changes — `history_screen.dart` already consumes an `AsyncValue` via `.when()`.
- Added `test/providers/available_texture_classes_provider_test.dart` (reactive add/remove, distinct, sorted, ignore-unclassified), written before the fix (red → green).

## 3. How to Test
1. Check out the branch.
2. `flutter pub get`
3. `dart run build_runner build --delete-conflicting-outputs`
4. `flutter test` (20 tests pass, including the 4 new ones)
5. `flutter analyze` (no issues)
6. Manual: capture a sample with a new texture class → its filter chip appears in History without restarting the app.

## 4. Evidence
State/logic fix (no new UI). Verified via the new provider tests + full suite green and clean analyze.

## 5. Self-Review Checklist
- [x] Self-review done in Files Changed
- [x] Spec approved at the Gate before implementation; change matches its Scope
- [x] Each Acceptance Criterion has a passing test; tests written before implementation (red → green)
- [x] No commented-out code or debug statements
- [x] Follows project style (kept existing formatting; no unrelated reformat)
- [x] No new dependencies
- **Review layers:** R1 internal self-review done; R2 cross-provider — not available, so R1 + human PR review stand in (per `ai_guidelines.md`); R3 — CodeRabbit on this PR.

## Spec (ephemeral — embedded, not committed to main)

### Problem
The history texture-filter chips can omit valid classes (and show none right after the first capture) because `availableTextureClassesProvider` queries the database once and never refreshes.

### Design Decision
Replace the one-shot `FutureProvider<List<String>>` with a `Provider<AsyncValue<List<String>>>` that derives the distinct texture classes from the existing `soilRecordsStreamProvider`, mirroring `latestSoilRecordProvider` and `homeStatsProvider`. The list is de-duplicated, sorted alphabetically for a stable chip order, and excludes unclassified records. No repository or consumer changes are needed.

### Alternatives Considered
- **Invalidate `availableTextureClassesProvider` on every DB write.** Rejected: every mutation site would have to remember to invalidate — fragile and the same failure mode that caused this bug.
- **Add a `watchDistinctTextureClasses()` Stream to the repository.** Rejected: a second DB subscription for data already in the `watchAll()` stream; deriving in the provider reuses the single existing subscription and matches the established pattern.

### Scope
- Includes: rewrite `availableTextureClassesProvider`; add a provider test covering reactive add/remove, distinct, sorted, and ignore-unclassified.
- Does NOT include: removing the now-unused `getDistinctTextureClasses()` repository method (kept as part of the repository contract, consistent with `getAll`/`getLatest`/`count`); any UI/consumer change; remote-sync work.

### Acceptance Criteria
- returns_empty_list_when_no_records
- adds_class_chip_reactively_when_new_classified_record_created
- removes_class_chip_when_last_record_of_class_deleted
- returns_distinct_sorted_classes_ignoring_unclassified_records
- flutter_analyze_passes
- flutter_test_passes

### Reproducibility
- `flutter test test/providers/available_texture_classes_provider_test.dart`
- `flutter analyze`
- Flutter 3.38.5 / Dart 3.10.4; Drift in-memory `NativeDatabase.memory()`.

Closes #46
