### PR TITLE
feat(share): implement record export and sharing

### DIFF
--- a/lib/core/features/details/details.dart
+++ b/lib/core/features/details/details.dart
@@ -10,6 +10,7 @@ import 'package:visiosoil_app/core/theme/soil_texture_colors.dart';
 import 'package:visiosoil_app/core/widgets/loading_indicator.dart';
 import 'package:visiosoil_app/models/confidence_level.dart';
 import 'package:visiosoil_app/models/soil_record.dart';
+import 'package:visiosoil_app/providers/share_service_provider.dart';
 import 'package:visiosoil_app/providers/soil_record_repository_provider.dart';
 
 class DetailsPage extends ConsumerWidget {
@@ -423,15 +424,9 @@ class _ActionButtons extends ConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        // Share placeholder
+        // Share
         OutlinedButton.icon(
-          onPressed: () {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(
-                content: Text('Compartilhamento em breve'),
-              ),
-            );
-          },
+          onPressed: () => _shareRecord(context, ref),
           icon: const Icon(Icons.share_outlined),
           label: const Text('Compartilhar'),
         ),
@@ -447,6 +442,19 @@ class _ActionButtons extends ConsumerWidget {
         ),
       ],
     );
+  }
+
+  Future<void> _shareRecord(BuildContext context, WidgetRef ref) async {
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref.read(shareServiceProvider).shareRecord(record);
+    } catch (_) {
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('Não foi possível compartilhar o registro.'),
+        ),
+      );
+    }
   }
 
   Future<void> _confirmAndDelete(BuildContext context, WidgetRef ref) async {

--- a/lib/core/services/share_content_builder.dart
+++ b/lib/core/services/share_content_builder.dart
@@ -1,0 +1,96 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/painting.dart';
+import 'package:visiosoil_app/models/soil_record.dart';
+
+/// Builds the shareable content for a [SoilRecord]: a plain-text caption and a
+/// composed PNG card (the photo with a metadata footer).
+///
+/// Pure and free of file I/O and platform calls so it can be unit-tested.
+/// [ShareService] handles loading the photo, writing the temp file, and the
+/// native share sheet.
+abstract final class ShareContentBuilder {
+  /// Card width in pixels; the photo is scaled to it and the footer spans it.
+  static const double _cardWidth = 1080;
+
+  /// Padding around the footer text, in pixels.
+  static const double _footerPadding = 32;
+
+  /// Plain-text caption with one metadata field per line; fields that are
+  /// missing or unavailable are omitted.
+  static String caption(SoilRecord record) {
+    final lines = <String>['VisioSoil — análise de solo'];
+    if (record.hasClassification) {
+      final confidence = record.confidenceScore != null
+          ? ' (${record.formattedConfidence})'
+          : '';
+      lines.add('Classe: ${record.displayTextureClass}$confidence');
+    }
+    if (record.hasValidAddress) {
+      lines.add('Local: ${record.address}');
+    }
+    if (record.hasCoordinates) {
+      lines.add('Coordenadas: ${record.formattedCoordinates}');
+    }
+    lines.add('Data: ${record.formattedTimestamp}');
+    return lines.join('\n');
+  }
+
+  /// Composes [photoBytes] with a metadata footer into a PNG card and returns
+  /// the encoded bytes. The photo is scaled to [_cardWidth] and the caption is
+  /// drawn in a footer band below it.
+  static Future<Uint8List> composeCard(
+    SoilRecord record,
+    Uint8List photoBytes,
+  ) async {
+    final codec = await ui.instantiateImageCodec(photoBytes);
+    final frame = await codec.getNextFrame();
+    final photo = frame.image;
+
+    final scale = _cardWidth / photo.width;
+    final photoHeight = photo.height * scale;
+
+    final footer = TextPainter(
+      text: TextSpan(
+        text: caption(record),
+        style: const TextStyle(
+          color: Color(0xFF1A1C19),
+          fontSize: 34,
+          height: 1.4,
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout(maxWidth: _cardWidth - _footerPadding * 2);
+
+    final cardHeight = photoHeight + footer.height + _footerPadding * 2;
+
+    final recorder = ui.PictureRecorder();
+    final canvas = ui.Canvas(
+      recorder,
+      ui.Rect.fromLTWH(0, 0, _cardWidth, cardHeight),
+    );
+
+    canvas.drawRect(
+      ui.Rect.fromLTWH(0, 0, _cardWidth, cardHeight),
+      ui.Paint()..color = const Color(0xFFFCFDF8),
+    );
+    canvas.drawImageRect(
+      photo,
+      ui.Rect.fromLTWH(0, 0, photo.width.toDouble(), photo.height.toDouble()),
+      ui.Rect.fromLTWH(0, 0, _cardWidth, photoHeight),
+      ui.Paint(),
+    );
+    footer.paint(canvas, Offset(_footerPadding, photoHeight + _footerPadding));
+
+    final picture = recorder.endRecording();
+    final image = await picture.toImage(_cardWidth.round(), cardHeight.ceil());
+    final data = await image.toByteData(format: ui.ImageByteFormat.png);
+
+    photo.dispose();
+    image.dispose();
+    picture.dispose();
+
+    return data!.buffer.asUint8List();
+  }
+}

--- a/lib/core/services/share_service.dart
+++ b/lib/core/services/share_service.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'package:share_plus/share_plus.dart';
+import 'package:visiosoil_app/core/services/share_content_builder.dart';
+import 'package:visiosoil_app/models/soil_record.dart';
+
+/// Shares a [SoilRecord] through the native share sheet.
+///
+/// Composes a PNG card from the record's photo and metadata, writes it to a
+/// temporary file, and hands it to `share_plus` with a text caption. Falls back
+/// to sharing the caption alone when the photo file is missing.
+class ShareService {
+  const ShareService();
+
+  Future<void> shareRecord(SoilRecord record) async {
+    final caption = ShareContentBuilder.caption(record);
+    final photoFile = File(record.imagePath);
+
+    if (!await photoFile.exists()) {
+      await SharePlus.instance.share(ShareParams(text: caption));
+      return;
+    }
+
+    final photoBytes = await photoFile.readAsBytes();
+    final cardBytes = await ShareContentBuilder.composeCard(record, photoBytes);
+
+    final tempDir = await Directory.systemTemp.createTemp('visiosoil_share');
+    final cardFile = File(
+      '${tempDir.path}/visiosoil_${record.id ?? 'record'}.png',
+    );
+    await cardFile.writeAsBytes(cardBytes);
+
+    await SharePlus.instance.share(
+      ShareParams(files: [XFile(cardFile.path)], text: caption),
+    );
+  }
+}

--- a/lib/providers/share_service_provider.dart
+++ b/lib/providers/share_service_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:visiosoil_app/core/services/share_service.dart';
+
+/// Provides the [ShareService] used to export and share records.
+final shareServiceProvider = Provider<ShareService>(
+  (ref) => const ShareService(),
+);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -616,6 +616,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -668,26 +676,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -928,6 +936,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.2"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   shelf:
     dependency: transitive
     description:
@@ -1073,26 +1097,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.12"
   tflite_flutter:
     dependency: "direct main"
     description:
@@ -1117,6 +1141,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   permission_handler: ^11.3.1
   # App info (version, build number)
   package_info_plus: ^8.0.0
+  share_plus: ^12.0.2
 
 dev_dependencies:
   flutter_test:

--- a/test/services/share_content_builder_test.dart
+++ b/test/services/share_content_builder_test.dart
@@ -1,0 +1,77 @@
+// Tests for [ShareContentBuilder]: the pure, I/O-free content used by the share
+// flow — the text caption and the composed PNG card. The native share sheet
+// (ShareService) is not unit-tested; it is verified manually.
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:visiosoil_app/core/services/share_content_builder.dart';
+import 'package:visiosoil_app/models/soil_record.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  SoilRecord record({
+    String? textureClass = 'Argilosa',
+    double? confidenceScore = 0.91,
+    double? latitude = -23.5,
+    double? longitude = -46.6,
+    String? address = 'São Paulo, SP',
+  }) {
+    return SoilRecord(
+      imagePath: '/img.jpg',
+      latitude: latitude,
+      longitude: longitude,
+      address: address,
+      timestamp: DateTime.utc(2026, 1, 2, 14, 30).toIso8601String(),
+      textureClass: textureClass,
+      confidenceScore: confidenceScore,
+    );
+  }
+
+  group('ShareContentBuilder.caption', () {
+    test('includes class, confidence, address and date when present', () {
+      final text = ShareContentBuilder.caption(record());
+
+      expect(text, contains('Argilosa'));
+      expect(text, contains('91.0%'));
+      expect(text, contains('São Paulo, SP'));
+      expect(text, contains('02/01/2026'));
+    });
+
+    test('omits fields that are missing or unavailable', () {
+      final text = ShareContentBuilder.caption(
+        record(
+          textureClass: null,
+          confidenceScore: null,
+          address: null,
+          latitude: null,
+          longitude: null,
+        ),
+      );
+
+      expect(text, isNot(contains('Classe:')));
+      expect(text, isNot(contains('Local:')));
+      expect(text, isNot(contains('Coordenadas:')));
+      expect(text, contains('Data:'));
+    });
+  });
+
+  group('ShareContentBuilder.composeCard', () {
+    test('returns a non-empty PNG taller than the source photo', () async {
+      final source = img.Image(width: 200, height: 150);
+      img.fill(source, color: img.ColorRgb8(120, 100, 80));
+      final photoBytes = Uint8List.fromList(img.encodePng(source));
+
+      final cardBytes =
+          await ShareContentBuilder.composeCard(record(), photoBytes);
+
+      expect(cardBytes, isNotEmpty);
+      final decoded = img.decodePng(cardBytes);
+      expect(decoded, isNotNull);
+      expect(decoded!.width, 1080);
+      // The footer band is drawn below the scaled photo (150 * 1080/200 = 810).
+      expect(decoded.height, greaterThan(810));
+    });
+  });
+}


### PR DESCRIPTION
## 1. Context
- **Motivation:** The Details "Compartilhar" button was a placeholder ("em breve"); there was no way to export or share a soil record.
- **Task Link:** Closes #5
- **Spec Link:** Spec embedded below (ephemeral — not committed to `main`, per project policy).

## 2. What Was Done
- Added `share_plus ^12.0.2`.
- `ShareContentBuilder` (pure): builds the text caption (class / confidence / address / coordinates / date, omitting missing fields) and composes a PNG card (photo + metadata footer) via `dart:ui` `Canvas` + `TextPainter`.
- `ShareService`: loads the photo, composes the card, writes a temp file (`Directory.systemTemp`), and opens the native share sheet via `SharePlus.instance.share(ShareParams(...))`; falls back to caption-only text when the photo file is missing.
- Added `shareServiceProvider` and wired the Details "Compartilhar" button to it (with an error snackbar).
- Unit tests for the builder (caption cases + composed-card smoke), written before the implementation (red → green).

## 3. How to Test
1. Check out the branch; `flutter pub get`.
2. `dart run build_runner build --delete-conflicting-outputs`
3. `flutter test` — 23 tests pass (3 new).
4. `flutter analyze` — no issues.
5. Manual (device/emulator): open a record → Details → "Compartilhar" → the native share sheet opens with a composed image card + caption.

## 4. Evidence
Automated tests cover the pure builders (caption + composed PNG dimensions). The native share sheet and the on-device card appearance require manual verification (cannot run in CI) — pending a device check before merge.

## 5. Self-Review Checklist
- [x] Self-review done in Files Changed
- [x] Spec approved at the Gate; change matches its Scope
- [x] Each automatable Acceptance Criterion has a passing test; tests written before implementation (red → green)
- [x] No commented-out code or debug statements
- [x] Uses the non-deprecated `share_plus` API (`SharePlus.instance.share`)
- [x] New dependency (`share_plus`) justified (native sharing) and builds clean
- **Review layers:** R1 internal self-review done; R2 cross-provider — not available, so R1 + human PR review stand in (per `ai_guidelines.md`); R3 — CodeRabbit on this PR.

## Spec (ephemeral — embedded, not committed to main)

### Problem
The Details screen "Compartilhar" button is a placeholder, so a soil record cannot be exported or shared.

### Design Decision
Add `share_plus` and share a single record from the Details screen. Build a composed PNG card with a `dart:ui` `Canvas` (photo + metadata footer rendered via `TextPainter`: class, confidence, address, coordinates, date), write it to a temp file, and open the native share sheet via `share_plus` with a text caption. The pure content builders are isolated from I/O and the native call so they are unit-testable; `TextPainter` renders pt-BR accents correctly (the `image` package's bitmap fonts do not, and a `RepaintBoundary` capture would require the card to be mounted in the widget tree).

### Alternatives Considered
- **Text-only share.** Rejected: the issue's acceptance criteria require a composed image with metadata.
- **`image` package `drawString`.** Rejected: bundled bitmap fonts drop pt-BR accents and look poor.
- **`RepaintBoundary` widget capture.** Rejected: requires the card mounted in the live tree; harder to unit-test.

### Scope
- Includes: `share_plus`; `ShareContentBuilder` (caption + composed PNG); `ShareService` (load photo, compose, temp file, native share); wire the Details button; unit tests for the builders.
- Does NOT include: batch/multi-record share; CSV/PDF export; remote upload; sharing from History or Preview; adding `path_provider`.

### Acceptance Criteria
- caption_includes_class_confidence_address_and_date_when_present
- caption_omits_fields_that_are_missing_or_unavailable
- composed_card_returns_nonempty_png_taller_than_the_source_photo
- share_button_on_details_invokes_the_share_flow (manual/integration)
- flutter_analyze_passes
- flutter_test_passes

### Reproducibility
- `flutter pub get`; `flutter test test/services/share_content_builder_test.dart`; `flutter analyze`
- Flutter 3.38.5 / Dart 3.10.4; `share_plus 12.0.2`.

Closes #5
