### PR TITLE
chore(perms): remove unused gallery and storage permissions (camera-only design)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 <uses-permission android:name="android.permission.CAMERA"/>
-<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-<uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <application

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -6,8 +6,6 @@
 	<string>Acesso à localização para marcação de amostras</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Acesso à câmera para captura de imagens</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Acesso à galeria para seleção de imagens</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
## Context

- **Motivation:** The app is camera-only by design (capture via `ImageSource.camera`), but the platform manifests still declared gallery/storage permissions left over after gallery selection was removed (#14, #12). This aligns declared permissions with least privilege and avoids App Store review questions about unused photo-library access.
- **Task Link:** Closes #48
- **Spec Link:** None — trivial configuration cleanup, exempt from the Spec Gate per `spec_method.md` (change too small to have a design).

## What Was Done

- Android (`android/app/src/main/AndroidManifest.xml`): removed `READ_EXTERNAL_STORAGE`, `WRITE_EXTERNAL_STORAGE`, and `READ_MEDIA_IMAGES`. Kept `CAMERA`, `ACCESS_FINE_LOCATION`, `ACCESS_COARSE_LOCATION`.
- iOS (`ios/Runner/Info.plist`): removed `NSPhotoLibraryUsageDescription`. Kept `NSCameraUsageDescription` and `NSLocationWhenInUseUsageDescription`.

Verified in code that nothing requests the removed permissions at runtime: `permission_service.dart` requests only `Permission.camera` and `Permission.locationWhenInUse`; capture uses `ImageSource.camera` (`capture_screen.dart:90`). `image_picker` camera capture needs none of the removed permissions.

## How to Test

1. Check out the branch.
2. `flutter pub get`
3. `flutter build apk --release` (covered by the CI build job).
4. On an Android 13+ device/emulator and an iOS device: capture a photo with the camera and save the record; confirm the flow still works without the removed permissions.

## Evidence

Configuration-only change; no UI change. No screenshots.

## Self-Review Checklist

- [x] Self-review done in the Files Changed tab.
- [N/A] Spec approved at the Gate — exempt (trivial config cleanup) per `spec_method.md`.
- [N/A] Each Acceptance Criterion has a passing test, written test-first — no Dart behavior to test; this is a platform-manifest change verified by build (CI) plus a manual device check.
- [x] No commented-out code or debug statements removed/left.
- [x] Code follows the project style guide.
- [x] No new dependencies.
- **Review layers:** R1 — author self-review per `ai_guidelines.md` (trivial config change; no subagent review warranted). R2 — no second-provider reviewer configured; R1 plus human PR review stand in. R3 — CodeRabbit on this PR.
