### PR TITLE
refactor(routes): remove orphan /history route

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ UI (Screens) → Riverpod Providers → Repository (abstract) → Drift DB / TFL
 ```
 
 - **State management:** `flutter_riverpod` — `Provider` for singletons, `StreamProvider` for reactive lists, `FutureProvider.family` for record-by-id lookups
-- **Navigation:** `go_router` with 8 routes. `/details` and `/preview` pass record id via `state.extra` (not URL params)
+- **Navigation:** `go_router` with 7 routes. `/details` and `/preview` pass record id via `state.extra` (not URL params)
 - **Persistence:** Drift + SQLite with schema versioning (currently v2). Repository pattern abstracts Drift from UI
 - **AI inference:** TFLite model runs in a separate Dart `Isolate` via `InferenceService` to avoid blocking UI. Model bytes loaded from assets since `rootBundle` is unavailable in isolates
 
@@ -72,7 +72,7 @@ lib/
 ├── main.dart                          # Entry: ProviderScope + MaterialApp.router
 ├── core/
 │   ├── theme/                         # AppTheme.light, AppColors, AppTypography, AppSpacing
-│   ├── routes/app_router.dart         # GoRouter config (8 routes)
+│   ├── routes/app_router.dart         # GoRouter config (7 routes)
 │   ├── widgets/                       # Reusable: VisioAppBar, VisioButton, EmptyState
 │   ├── utils/                         # LocationService (GPS+geocoding), Formatters
 │   ├── services/inference_service.dart # TFLite classification (isolate-based)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ visiosoil-app/
 │   ├── main.dart            # Entry: ProviderScope + MaterialApp.router
 │   ├── core/
 │   │   ├── theme/           # AppTheme, AppColors, AppTypography, AppSpacing
-│   │   ├── routes/          # GoRouter config (8 routes)
+│   │   ├── routes/          # GoRouter config (7 routes)
 │   │   ├── widgets/         # VisioAppBar, VisioButton, EmptyState
 │   │   ├── utils/           # LocationService (GPS + geocoding), formatters
 │   │   ├── services/        # InferenceService (TFLite, isolate) + PermissionService
@@ -123,7 +123,7 @@ visiosoil-app/
 
 ### Done
 
-- [x] Material 3 theme, Riverpod state management, GoRouter navigation (8 routes)
+- [x] Material 3 theme, Riverpod state management, GoRouter navigation (7 routes)
 - [x] Splash screen with runtime permission requests via `PermissionService`
 - [x] 3-step onboarding capture tutorial
 - [x] Bottom navigation shell (`MainScreen`) with home and history tabs

--- a/lib/core/routes/app_router.dart
+++ b/lib/core/routes/app_router.dart
@@ -1,7 +1,6 @@
 import 'package:go_router/go_router.dart';
 import 'package:visiosoil_app/core/features/capture/capture_screen.dart';
 import 'package:visiosoil_app/core/features/details/details.dart';
-import 'package:visiosoil_app/core/features/history/history_screen.dart';
 import 'package:visiosoil_app/core/features/main/main_screen.dart';
 import 'package:visiosoil_app/core/features/onboarding/onboarding_screen.dart';
 import 'package:visiosoil_app/core/features/preview/image_preview_screen.dart';
@@ -14,7 +13,6 @@ final appRouter = GoRouter(
     GoRoute(path: '/splash', builder: (context, state) => const SplashScreen()),
     GoRoute(path: '/', builder: (context, state) => const MainScreen()),
     GoRoute(path: '/capture', builder: (context, state) => const CaptureScreen()),
-    GoRoute(path: '/history', builder: (context, state) => const HistoryScreen()),
     GoRoute(
       path: '/details',
       builder: (context, state) {

--- a/test/routes/app_router_test.dart
+++ b/test/routes/app_router_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:visiosoil_app/core/routes/app_router.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('appRouter', () {
+    List<String> topLevelPaths() => appRouter.configuration.routes
+        .whereType<GoRoute>()
+        .map((route) => route.path)
+        .toList();
+
+    test('does not register the orphan /history route', () {
+      expect(topLevelPaths(), isNot(contains('/history')));
+    });
+
+    test('still registers the core navigable routes', () {
+      expect(
+        topLevelPaths(),
+        containsAll(<String>[
+          '/splash',
+          '/',
+          '/capture',
+          '/details',
+          '/preview',
+          '/onboarding',
+          '/settings',
+        ]),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Context

- **Motivation:** The `/history` route was registered in `app_router.dart` but unreachable — nothing navigates to it. History is reached only as a tab inside `MainScreen` via `IndexedStack`. This removes the dead navigation surface (same class of debt as #37).
- **Task Link:** Closes #47
- **Spec Link:** None — trivial refactor (one route + its now-unused import, plus a doc count), exempt from the Spec Gate per `spec_method.md`.
- **Decision:** The issue offered Remove vs Keep; chose **Remove** (no deep-linking need today). `HistoryScreen` itself is unchanged — it stays in use by the `MainScreen` tab.

## What Was Done

- Removed the `/history` `GoRoute` and the now-unused `HistoryScreen` import from `lib/core/routes/app_router.dart` (7 routes remain).
- Updated the route count from 8 to 7 in `CLAUDE.md` (x2) and `README.md` (x2).
- Added `test/routes/app_router_test.dart` asserting `/history` is not registered and the core routes still are.

## How to Test

1. Check out the branch.
2. `flutter pub get`
3. `flutter test test/routes/app_router_test.dart` — both cases pass.
4. `flutter analyze` — no issues (confirms no orphaned import).

## Evidence

`flutter test`: 25/25 pass (23 existing + 2 new router tests). `flutter analyze`: "No issues found!". No UI change.

## Self-Review Checklist

- [x] Self-review done in the Files Changed tab.
- [N/A] Spec approved at the Gate — exempt (trivial refactor) per `spec_method.md`.
- [x] Each Acceptance Criterion has a passing test; the test was written and committed before the implementation (red commit `test(routes): ...`, then green `refactor(routes): ...`).
- [x] No commented-out code or debug statements.
- [x] Code follows the project style guide; `flutter analyze` clean.
- [x] No new dependencies.
- **Review layers:** R1 — author self-review per `ai_guidelines.md` (trivial refactor). R2 — no second-provider reviewer configured; R1 plus human PR review stand in. R3 — CodeRabbit on this PR.
