### PR TITLE
fix(location): handle geocoding failures and null placemark fields

### DIFF
--- a/lib/core/utils/location_service.dart
+++ b/lib/core/utils/location_service.dart
@@ -1,6 +1,14 @@
+import 'package:flutter/foundation.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:geocoding/geocoding.dart';
 import 'package:visiosoil_app/core/constants/app_strings.dart';
+
+/// Signature for the reverse-geocoding lookup. Injected so tests can supply
+/// placemarks or simulate failures without the platform geocoding plugin.
+typedef PlacemarkResolver = Future<List<Placemark>> Function(
+  double latitude,
+  double longitude,
+);
 
 class LocationService {
   static Future<Position> getCurrentLocation() async {
@@ -27,13 +35,39 @@ class LocationService {
     return await Geolocator.getCurrentPosition();
   }
 
-  static Future<String> getAddressFromPosition(Position position) async {
-    List<Placemark> placemarks = await placemarkFromCoordinates(
-      position.latitude,
-      position.longitude,
-    );
+  /// Reverse-geocodes [position] into a human-readable address.
+  ///
+  /// Geocoding is best-effort: the coordinates are the source of truth, so any
+  /// lookup failure or empty result degrades to [AppStrings.addressUnavailable]
+  /// instead of propagating, letting the caller keep the coordinates.
+  static Future<String> getAddressFromPosition(
+    Position position, {
+    PlacemarkResolver? geocoder,
+  }) async {
+    final resolve = geocoder ?? placemarkFromCoordinates;
+
+    List<Placemark> placemarks;
+    try {
+      placemarks = await resolve(position.latitude, position.longitude);
+    } catch (_) {
+      // Geocoding is an external I/O boundary; a broad catch is intentional so
+      // a network or platform failure degrades to the fallback address.
+      return AppStrings.addressUnavailable;
+    }
+
     if (placemarks.isEmpty) return AppStrings.addressUnavailable;
-    Placemark placemark = placemarks[0];
-    return '${placemark.street}, ${placemark.locality}, ${placemark.administrativeArea}';
+
+    final address = formatPlacemarkAddress(placemarks.first);
+    return address.isEmpty ? AppStrings.addressUnavailable : address;
+  }
+
+  /// Joins the meaningful parts of [placemark] into a single address line,
+  /// skipping null or blank fields so absent data never leaks as "null".
+  @visibleForTesting
+  static String formatPlacemarkAddress(Placemark placemark) {
+    return [placemark.street, placemark.locality, placemark.administrativeArea]
+        .whereType<String>()
+        .where((part) => part.isNotEmpty)
+        .join(', ');
   }
 }

--- a/test/utils/location_service_test.dart
+++ b/test/utils/location_service_test.dart
@@ -58,7 +58,7 @@ void main() {
         () async {
       final address = await LocationService.getAddressFromPosition(
         fakePosition(),
-        geocoder: (_, __) async => <Placemark>[],
+        geocoder: (_, _) async => <Placemark>[],
       );
       expect(address, AppStrings.addressUnavailable);
     });
@@ -66,7 +66,7 @@ void main() {
     test('returns the fallback when the geocoder throws', () async {
       final address = await LocationService.getAddressFromPosition(
         fakePosition(),
-        geocoder: (_, __) async => throw Exception('geocoding failed'),
+        geocoder: (_, _) async => throw Exception('geocoding failed'),
       );
       expect(address, AppStrings.addressUnavailable);
     });
@@ -75,7 +75,7 @@ void main() {
         () async {
       final address = await LocationService.getAddressFromPosition(
         fakePosition(),
-        geocoder: (_, __) async => [Placemark()],
+        geocoder: (_, _) async => [Placemark()],
       );
       expect(address, AppStrings.addressUnavailable);
     });
@@ -83,7 +83,7 @@ void main() {
     test('returns the formatted address for a valid placemark', () async {
       final address = await LocationService.getAddressFromPosition(
         fakePosition(),
-        geocoder: (_, __) async => [
+        geocoder: (_, _) async => [
           Placemark(
             street: 'Rua das Flores',
             locality: 'Sorriso',

--- a/test/utils/location_service_test.dart
+++ b/test/utils/location_service_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geocoding/geocoding.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:visiosoil_app/core/constants/app_strings.dart';
+import 'package:visiosoil_app/core/utils/location_service.dart';
+
+void main() {
+  Position fakePosition() => Position(
+        latitude: -12.0,
+        longitude: -55.0,
+        timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+        accuracy: 0,
+        altitude: 0,
+        altitudeAccuracy: 0,
+        heading: 0,
+        headingAccuracy: 0,
+        speed: 0,
+        speedAccuracy: 0,
+      );
+
+  group('LocationService.formatPlacemarkAddress', () {
+    test('joins present fields with a comma', () {
+      final placemark = Placemark(
+        street: 'Rua das Flores',
+        locality: 'Sorriso',
+        administrativeArea: 'MT',
+      );
+      expect(
+        LocationService.formatPlacemarkAddress(placemark),
+        'Rua das Flores, Sorriso, MT',
+      );
+    });
+
+    test('omits null and empty fields', () {
+      final placemark = Placemark(
+        street: 'Rua das Flores',
+        locality: null,
+        administrativeArea: '',
+      );
+      expect(
+        LocationService.formatPlacemarkAddress(placemark),
+        'Rua das Flores',
+      );
+    });
+
+    test('returns empty when all fields are absent', () {
+      final placemark = Placemark(
+        street: null,
+        locality: '',
+        administrativeArea: null,
+      );
+      expect(LocationService.formatPlacemarkAddress(placemark), '');
+    });
+  });
+
+  group('LocationService.getAddressFromPosition', () {
+    test('returns the fallback when the geocoder returns an empty list',
+        () async {
+      final address = await LocationService.getAddressFromPosition(
+        fakePosition(),
+        geocoder: (_, __) async => <Placemark>[],
+      );
+      expect(address, AppStrings.addressUnavailable);
+    });
+
+    test('returns the fallback when the geocoder throws', () async {
+      final address = await LocationService.getAddressFromPosition(
+        fakePosition(),
+        geocoder: (_, __) async => throw Exception('geocoding failed'),
+      );
+      expect(address, AppStrings.addressUnavailable);
+    });
+
+    test('returns the fallback when the placemark has no usable fields',
+        () async {
+      final address = await LocationService.getAddressFromPosition(
+        fakePosition(),
+        geocoder: (_, __) async => [Placemark()],
+      );
+      expect(address, AppStrings.addressUnavailable);
+    });
+
+    test('returns the formatted address for a valid placemark', () async {
+      final address = await LocationService.getAddressFromPosition(
+        fakePosition(),
+        geocoder: (_, __) async => [
+          Placemark(
+            street: 'Rua das Flores',
+            locality: 'Sorriso',
+            administrativeArea: 'MT',
+          ),
+        ],
+      );
+      expect(address, 'Rua das Flores, Sorriso, MT');
+    });
+  });
+}


### PR DESCRIPTION
## Context

- **Motivation:** `LocationService.getAddressFromPosition` propagated geocoding exceptions (silently dropping the address) and interpolated absent placemark fields as the literal string `"null"`, producing user-visible addresses like `"null, Sorriso, null"`.
- **Task Link:** Closes #24
- **Spec Link:** Approved at the Spec Gate — embedded below (kept out of `main` per the project's ephemeral-spec practice).
- **Note:** Problem 3 from the issue (rate-limiting/throttling location requests) is **deferred to #22**, whose scope is the capture-screen race conditions where rapid taps originate. Recorded on #22.

## What Was Done

- Wrapped the reverse-geocoding call in a boundary `try/catch` that degrades to `AppStrings.addressUnavailable` on any failure or empty result, so the record keeps its coordinates.
- Built the address by filtering out null/blank fields (`street`, `locality`, `administrativeArea`) before joining, and fall back when nothing usable remains.
- Extracted the formatting into a `@visibleForTesting` pure helper `formatPlacemarkAddress`, and made the geocoder injectable (`PlacemarkResolver`, default = `placemarkFromCoordinates`) so the formatting and exception paths are unit-testable without the platform plugin.
- No change to `capture_screen.dart` — the caller already handled the fallback.

## How to Test

1. Check out the branch.
2. `flutter pub get`
3. `flutter test test/utils/location_service_test.dart` — 7 cases pass.
4. `flutter analyze` — no issues.

## Evidence

`flutter test`: 30/30 pass (23 existing + 7 new). `flutter analyze`: "No issues found!". Backend/util change only — no UI screenshots.

## Self-Review Checklist

- [x] Self-review done in the Files Changed tab.
- [x] Spec approved at the Gate before implementation; the change matches its Scope (problem 3 explicitly out of scope, deferred to #22).
- [x] Each Acceptance Criterion has a passing test; tests were committed first (`test(location): ...`, red) before the implementation (`fix(location): ...`, green).
- [x] No commented-out code or debug statements.
- [x] Code follows the project style guide; `flutter analyze` clean.
- [x] No new dependencies.
- **Review layers:** R1 — author self-review per `ai_guidelines.md`. R2 — no second-provider reviewer configured; R1 plus human PR review stand in. R3 — CodeRabbit on this PR.

---

## SPEC (approved at the Gate)

# SPEC: fix(location): handle geocoding failures and null placemark fields

### Problem
`LocationService.getAddressFromPosition` crashes-to-silent-drop on geocoding errors and writes literal `"null"` fragments into saved/displayed addresses when placemark fields are absent.

### Design Decision
Keep `LocationService` static (minimal churn, `patch` scope). Make `getAddressFromPosition` resilient: a boundary `try/catch` returns `AppStrings.addressUnavailable` on failure/empty result (coordinates are the source of truth, preserved by the caller). Build the address by filtering null/empty fields before joining, with a fallback when nothing usable remains. Extract a `@visibleForTesting` pure formatter and inject the geocoder (default = real `placemarkFromCoordinates`) so both paths are testable without platform plugins.

### Alternatives Considered
1. Convert `LocationService` to a Riverpod-provided instance with injected seams — rejected for #24: rewires the caller and collides with #22; out of scope for a `patch`.
2. Change the signature to `(double lat, double lng)` — rejected: churns the caller for no functional gain; the injected geocoder already enables testing.
3. Implement service-level throttling here — rejected: the rapid-tap source is the capture UI (#22), the camera is modal so parallel requests are unlikely, and coalescing needs static mutable state. Deferred to #22.

### Scope
- **Includes:** boundary `try/catch` around geocoding with fallback; null/empty field filtering with fallback; `@visibleForTesting` formatter + injectable geocoder; unit tests per criterion.
- **Does NOT include:** problem 3 throttling (→ #22); `getCurrentLocation` error-string/behavior changes; instance/provider conversion; `capture_screen.dart` changes.

### Acceptance Criteria
1. `formatPlacemarkAddress_joins_present_fields_with_comma`
2. `formatPlacemarkAddress_omits_null_and_empty_fields`
3. `formatPlacemarkAddress_returns_empty_when_all_fields_absent`
4. `getAddressFromPosition_returns_fallback_when_geocoder_returns_empty_list`
5. `getAddressFromPosition_returns_fallback_when_geocoder_throws`
6. `getAddressFromPosition_returns_formatted_address_for_a_valid_placemark`

### Reproducibility
`flutter test test/utils/location_service_test.dart` (Flutter 3.38.5 / Dart 3.10.4); full gate `flutter analyze` + `flutter test`.

### Risks and Assumptions
- `placemarkFromCoordinates` (geocoding 4.0.0) is assignable to `PlacemarkResolver` (its `localeIdentifier` is optional) — verified at green.
- Returning a fallback string (not rethrowing) is the desired degradation, per the issue.
- The broad `catch` at the geocoding boundary is intentional per `code_conventions.md`.
