### PR TITLE
fix(inference): silent failures and no retry in InferenceService

### DIFF
--- a/lib/core/services/inference_service.dart
+++ b/lib/core/services/inference_service.dart
@@ -29,6 +29,10 @@ class _InferenceParams {
   });
 }
 
+/// Signature for loading the model asset. Injected so tests can drive the
+/// initialization retry logic without the platform asset bundle.
+typedef ModelAssetLoader = Future<ByteData> Function(String key);
+
 /// TensorFlow Lite inference service for soil texture classification.
 ///
 /// Loads the model from assets, preprocesses images, and runs inference
@@ -50,45 +54,73 @@ class InferenceService {
     'Argilosa',
   ];
 
+  /// Maximum attempts to load the model before giving up for the current call.
+  static const int _maxInitAttempts = 3;
+
+  /// Delay between initialization retries.
+  static const Duration _initRetryDelay = Duration(milliseconds: 300);
+
+  /// Maximum time to wait for the model asset to load.
+  static const Duration _modelLoadTimeout = Duration(seconds: 5);
+
+  /// Maximum time to wait for a single inference run before giving up.
+  static const Duration _inferenceTimeout = Duration(seconds: 15);
+
   Uint8List? _modelBytes;
   bool _isInitialized = false;
-  bool _initializationAttempted = false;
+
+  /// Set when the model asset is empty or absent — a build-time fact that
+  /// retrying cannot fix, so further initialization attempts are skipped.
+  bool _modelUnavailable = false;
 
   /// Indicates whether the service is ready for inference.
   bool get isReady => _isInitialized && _modelBytes != null;
 
   /// Initializes the service by loading the model from assets.
   ///
-  /// Returns `true` if initialized successfully, `false` otherwise.
-  /// The model is loaded as bytes so it can be passed to the isolate.
-  /// If initialization was already attempted and failed, returns `false` immediately.
-  Future<bool> initialize() async {
+  /// Returns `true` once the model bytes are loaded, `false` otherwise. The
+  /// model is loaded as bytes so it can be passed to the isolate. Transient
+  /// failures are retried with a short backoff; an empty or absent model is a
+  /// build-time fact and is not retried (see [_modelUnavailable]).
+  ///
+  /// [assetLoader] and [retryDelay] are injectable for tests.
+  Future<bool> initialize({
+    ModelAssetLoader? assetLoader,
+    Duration retryDelay = _initRetryDelay,
+  }) async {
     if (_isInitialized) return true;
+    if (_modelUnavailable) return false;
 
-    // Avoids repeated attempts to load a nonexistent model
-    if (_initializationAttempted) return false;
-    _initializationAttempted = true;
+    final load = assetLoader ?? rootBundle.load;
 
-    try {
-      // Timeout to avoid hanging if the file does not exist
-      final byteData = await rootBundle.load(_modelPath).timeout(
-        const Duration(seconds: 5),
-        onTimeout: () => throw Exception('Timeout loading model'),
-      );
-      if (byteData.lengthInBytes == 0) {
-        return false;
+    for (var attempt = 1; attempt <= _maxInitAttempts; attempt++) {
+      try {
+        final byteData = await load(_modelPath).timeout(
+          _modelLoadTimeout,
+          onTimeout: () => throw Exception('Timeout loading model'),
+        );
+        if (byteData.lengthInBytes == 0) {
+          // An empty model will not change without a new build: do not retry.
+          _modelUnavailable = true;
+          return false;
+        }
+        _modelBytes = byteData.buffer.asUint8List();
+        _isInitialized = true;
+        return true;
+      } catch (e) {
+        developer.log(
+          'Failed to initialize InferenceService '
+          '(attempt $attempt/$_maxInitAttempts): $e',
+          name: 'InferenceService',
+        );
+        if (attempt < _maxInitAttempts) {
+          await Future<void>.delayed(retryDelay);
+        }
       }
-      _modelBytes = byteData.buffer.asUint8List();
-      _isInitialized = true;
-      return true;
-    } catch (e) {
-      developer.log(
-        'Failed to initialize InferenceService: $e',
-        name: 'InferenceService',
-      );
-      _isInitialized = false;
-      return false;
     }
+
+    // Transient failures exhausted for this call; a later call may retry.
+    return false;
   }
 
   /// Runs soil texture classification on an image.
@@ -108,11 +140,12 @@ class InferenceService {
         imagePath: imagePath,
         modelBytes: _modelBytes!,
       );
-      final result = await Isolate.run(() => _runInference(params));
+      final result = await Isolate.run(() => _runInference(params))
+          .timeout(_inferenceTimeout);
       return result;
     } catch (e) {
       developer.log(
-        'classify() failed for $imagePath: $e',
+        'classify() failed: $e',
         name: 'InferenceService',
       );
       return null;
@@ -164,17 +197,19 @@ class InferenceService {
         }
       }
 
-      // Maps index to label
-      final label = maxIndex < _textureLabels.length
-          ? _textureLabels[maxIndex]
-          : 'Classe $maxIndex';
+      // Rejects incompatible models instead of fabricating a label.
+      final label = resolveTextureLabel(maxIndex, numClasses);
+      if (label == null) return null;
 
       return InferenceResult(
         textureClass: label,
         confidenceScore: maxProb,
       );
     } catch (e) {
-      debugPrint('InferenceService._runInference failed: $e');
+      developer.log(
+        'InferenceService._runInference failed: $e',
+        name: 'InferenceService',
+      );
       return null;
     }
   }
@@ -202,10 +237,20 @@ class InferenceService {
     return input;
   }
 
+  /// Maps the predicted [index] to a soil texture label, rejecting models whose
+  /// output [numClasses] does not match the known labels (returns null) so an
+  /// incompatible model never yields a fabricated, plausible-looking result.
+  @visibleForTesting
+  static String? resolveTextureLabel(int index, int numClasses) {
+    if (numClasses != _textureLabels.length) return null;
+    if (index < 0 || index >= _textureLabels.length) return null;
+    return _textureLabels[index];
+  }
+
   /// Releases the service's resources.
   void dispose() {
     _modelBytes = null;
     _isInitialized = false;
-    _initializationAttempted = false;
+    _modelUnavailable = false;
   }
 }

--- a/test/services/inference_service_test.dart
+++ b/test/services/inference_service_test.dart
@@ -1,0 +1,97 @@
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:visiosoil_app/core/services/inference_service.dart';
+
+void main() {
+  ByteData bytesOfLength(int length) =>
+      Uint8List.fromList(List<int>.filled(length, 1)).buffer.asByteData();
+
+  group('InferenceService.initialize', () {
+    test('returns true when the loader succeeds', () async {
+      final service = InferenceService();
+      final result = await service.initialize(
+        assetLoader: (_) async => bytesOfLength(8),
+        retryDelay: Duration.zero,
+      );
+      expect(result, isTrue);
+      expect(service.isReady, isTrue);
+    });
+
+    test('retries transient failures then succeeds', () async {
+      var calls = 0;
+      final service = InferenceService();
+      final result = await service.initialize(
+        retryDelay: Duration.zero,
+        assetLoader: (_) async {
+          calls++;
+          if (calls < 3) throw Exception('transient');
+          return bytesOfLength(8);
+        },
+      );
+      expect(result, isTrue);
+      expect(calls, 3);
+    });
+
+    test('marks an empty model permanently unavailable', () async {
+      var calls = 0;
+      Future<ByteData> loader(String _) async {
+        calls++;
+        return bytesOfLength(0);
+      }
+
+      final service = InferenceService();
+      final first = await service.initialize(
+        assetLoader: loader,
+        retryDelay: Duration.zero,
+      );
+      final second = await service.initialize(
+        assetLoader: loader,
+        retryDelay: Duration.zero,
+      );
+
+      expect(first, isFalse);
+      expect(second, isFalse);
+      expect(calls, 1); // empty model is permanent: loader not invoked again
+    });
+
+    test('allows a new attempt after transient failures exhaust', () async {
+      var calls = 0;
+      Future<ByteData> loader(String _) async {
+        calls++;
+        throw Exception('transient');
+      }
+
+      final service = InferenceService();
+      final first = await service.initialize(
+        assetLoader: loader,
+        retryDelay: Duration.zero,
+      );
+      final callsAfterFirst = calls;
+      final second = await service.initialize(
+        assetLoader: loader,
+        retryDelay: Duration.zero,
+      );
+
+      expect(first, isFalse);
+      expect(second, isFalse);
+      expect(callsAfterFirst, 3); // bounded attempts per call
+      expect(calls, greaterThan(callsAfterFirst)); // not permanently locked
+    });
+  });
+
+  group('InferenceService.resolveTextureLabel', () {
+    test('returns the label for a valid index when the class count matches', () {
+      expect(InferenceService.resolveTextureLabel(2, 5), 'Siltosa');
+    });
+
+    test('returns null when the class count mismatches the labels', () {
+      expect(InferenceService.resolveTextureLabel(0, 3), isNull);
+    });
+
+    test('returns null for an out-of-range index', () {
+      expect(InferenceService.resolveTextureLabel(7, 5), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Context

- **Motivation:** `InferenceService` failed unsafely — a single init failure blocked all future attempts until app restart, errors were swallowed (with a release-stripped `debugPrint` and a logged user file path), `Isolate.run` had no timeout, and an incompatible model produced a fabricated `Classe N` label instead of being rejected.
- **Task Link:** Closes #23
- **Spec Link:** Approved at the Spec Gate — embedded below (kept out of `main` per the project's ephemeral-spec practice).
- **Deferrals (approved at the Gate):** #5 (loading labels/config from `spec.json` at runtime) remains the `CLAUDE.md` tech-debt item / relates to #30 — only model-compatibility rejection (#6) is delivered here. #2 (user-facing failure message in the UI) is deferred to #9/#22, out of this issue's single-file scope.

## What Was Done

All within `lib/core/services/inference_service.dart`:
- Replaced the permanent `_initializationAttempted` lock with a bounded retry loop (backoff) over the model load; only an empty/zero-length model is treated as permanently unavailable (`_modelUnavailable`). No app restart needed after a transient failure.
- Added `@visibleForTesting resolveTextureLabel(index, numClasses)` that returns `null` on class-count mismatch or out-of-range index; `_runInference` now rejects (returns `null`) instead of fabricating `Classe N`.
- `debugPrint` → `developer.log` in `_runInference` (visible in release); dropped the image path from `classify`'s failure log.
- Added `.timeout(_inferenceTimeout)` to `Isolate.run`.
- Made the asset loader and retry delay injectable so init/retry is unit-testable without the platform bundle.
- `classify`'s `InferenceResult?` contract is unchanged — `capture_screen.dart` untouched.

## How to Test

1. Check out the branch.
2. `flutter pub get`
3. `flutter test test/services/inference_service_test.dart` — 7 cases pass.
4. `flutter analyze` — no issues.

## Evidence

`flutter test`: 30/30 pass (23 existing + 7 new). `flutter analyze`: "No issues found!". Service-only change — no UI screenshots.

## Self-Review Checklist

- [x] Self-review done in the Files Changed tab.
- [x] Spec approved at the Gate before implementation; the change matches its Scope (#5 and #2 explicitly deferred).
- [x] Each testable Acceptance Criterion has a passing test, committed first (`test(inference): ...`, red) before the implementation (`fix(inference): ...`, green).
- [x] No commented-out code or debug statements (`debugPrint` removed).
- [x] Code follows the project style guide; `flutter analyze` clean.
- [x] No new dependencies.
- **Not separately unit-tested (declared in the spec):** isolate timeout and logging side-effects — not unit-testable without a real model/isolate; verified by analyze + review.
- **Review layers:** R1 — author self-review per `ai_guidelines.md`. R2 — no second-provider reviewer configured; R1 plus human PR review stand in. R3 — CodeRabbit on this PR.

---

## SPEC (approved at the Gate)

# SPEC: fix(inference): harden InferenceService failure handling

### Problem
`InferenceService` permanently blocks re-initialization after one failure, silently swallows errors (with a release-stripped `debugPrint` and a logged user filesystem path), has no isolate timeout, and fabricates a `Classe N` label for incompatible models instead of rejecting them.

### Design Decision
Confine changes to `inference_service.dart`. Replace the permanent init lock with a bounded retry loop (backoff) that re-attempts transient errors and treats only an empty/zero-length model as permanent. Extract label resolution into a `@visibleForTesting` pure helper that rejects (returns `null`) a model whose output class count ≠ label count or whose index is out of range. Switch `debugPrint` to `developer.log`, drop the image path from the failure log, and add a timeout to `Isolate.run`. Make the asset loader injectable so init/retry is unit-testable. `classify`'s `InferenceResult?` contract is unchanged.

### Alternatives Considered
1. Change `classify` to a sealed success/failure result for actionable UI messages (#2) — rejected: requires editing `capture_screen.dart` (outside this single-file issue) and overlaps with #9/#22.
2. Load labels/input size from `spec.json` at runtime (#5) — rejected: it is the standing tech-debt feature (CLAUDE.md, relates to #30); #23 delivers the safety half (model rejection, #6) only.
3. Kill the isolate on timeout — rejected: `Isolate.run` exposes no kill handle; `.timeout` unblocks the UI Future (the visible freeze), documented as a known limitation.

### Scope
- **Includes:** bounded init retry with backoff + permanent empty-model flag (injectable loader/delay); `resolveTextureLabel` rejecting incompatible/out-of-range; `developer.log` instead of `debugPrint`; image path removed from logs; `Isolate.run` timeout; unit tests for retry + label resolution.
- **Does NOT include:** #2 UI surfacing (→ #9/#22); #5 runtime `spec.json` loading (→ tech debt / #30); changes to `classify`'s return contract or `capture_screen.dart`; unit tests for timeout/logging side-effects.

### Acceptance Criteria
1. `initialize_returns_true_when_loader_succeeds`
2. `initialize_retries_transient_failures_then_succeeds`
3. `initialize_marks_empty_model_permanently_unavailable`
4. `initialize_allows_a_new_attempt_after_transient_failures_exhaust`
5. `resolveTextureLabel_returns_label_for_valid_index_when_class_count_matches`
6. `resolveTextureLabel_returns_null_when_class_count_mismatches`
7. `resolveTextureLabel_returns_null_for_out_of_range_index`

### Reproducibility
`flutter test test/services/inference_service_test.dart` (Flutter 3.38.5 / Dart 3.10.4); full gate `flutter analyze` + `flutter test`.

### Risks and Assumptions
- `rootBundle.load` is assignable to the injectable loader type; defaulted via `?? rootBundle.load`.
- Re-attempting init on each `classify()` when the model is genuinely absent is acceptable (captures are user-initiated) and is the intended fix for "restart required".
- `.timeout` on `Isolate.run` unblocks the await but does not terminate a hung isolate (known limitation).
