### PR TITLE
fix(capture): race conditions and missing error handling in CaptureScreen

### DIFF
--- a/lib/core/features/capture/capture_screen.dart
+++ b/lib/core/features/capture/capture_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:developer' as developer;
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -18,8 +19,32 @@ import 'package:visiosoil_app/providers/image_provider.dart';
 import 'package:visiosoil_app/providers/inference_provider.dart';
 import 'package:visiosoil_app/providers/soil_record_repository_provider.dart';
 
+/// A device location reading: coordinates plus a reverse-geocoded address.
+typedef LocationReading = ({double latitude, double longitude, String address});
+
+/// Resolves the current device location, or `null` when unavailable.
+typedef LocationResolver = Future<LocationReading?> Function();
+
+/// Opens the camera and returns the captured image, or `null` if cancelled.
+typedef CameraImagePicker = Future<XFile?> Function();
+
+/// Reports a camera permission status.
+typedef CameraPermissionProbe = Future<AppPermissionStatus> Function();
+
 class CaptureScreen extends ConsumerStatefulWidget {
-  const CaptureScreen({super.key});
+  const CaptureScreen({
+    super.key,
+    this.pickFromCamera,
+    this.locate,
+    this.checkCameraPermission,
+    this.requestCameraPermission,
+  });
+
+  /// Test seams; each defaults to the real platform implementation.
+  final CameraImagePicker? pickFromCamera;
+  final LocationResolver? locate;
+  final CameraPermissionProbe? checkCameraPermission;
+  final CameraPermissionProbe? requestCameraPermission;
 
   @override
   ConsumerState<CaptureScreen> createState() => _CaptureScreenState();
@@ -27,14 +52,31 @@ class CaptureScreen extends ConsumerStatefulWidget {
 
 class _CaptureScreenState extends ConsumerState<CaptureScreen>
     with WidgetsBindingObserver {
+  static const Duration _locationTimeout = Duration(seconds: 20);
+  static const Duration _classificationTimeout = Duration(seconds: 20);
+
   bool _isLoading = false;
   bool _isClassifying = false;
   bool _isSaving = false;
+  bool _isCapturing = false;
+  bool _classificationFailed = false;
   String? _address;
   double? _latitude;
   double? _longitude;
   InferenceResult? _classificationResult;
   AppPermissionStatus? _cameraPermissionStatus;
+
+  /// Monotonic token identifying the current capture. Async results from a
+  /// superseded or discarded capture carry a stale token and are ignored.
+  int _requestGeneration = 0;
+
+  late final CameraImagePicker _pickFromCamera =
+      widget.pickFromCamera ?? _defaultPickFromCamera;
+  late final LocationResolver _locate = widget.locate ?? _defaultLocate;
+  late final CameraPermissionProbe _checkCameraPermission =
+      widget.checkCameraPermission ?? PermissionService.checkCamera;
+  late final CameraPermissionProbe _requestCameraPermission =
+      widget.requestCameraPermission ?? PermissionService.requestCamera;
 
   @override
   void initState() {
@@ -58,8 +100,21 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen>
     }
   }
 
+  Future<XFile?> _defaultPickFromCamera() =>
+      ImagePicker().pickImage(source: ImageSource.camera);
+
+  Future<LocationReading?> _defaultLocate() async {
+    final position = await LocationService.getCurrentLocation();
+    final address = await LocationService.getAddressFromPosition(position);
+    return (
+      latitude: position.latitude,
+      longitude: position.longitude,
+      address: address,
+    );
+  }
+
   Future<void> _recheckCameraPermission() async {
-    final status = await PermissionService.checkCamera();
+    final status = await _checkCameraPermission();
     if (!mounted) return;
 
     if (status == AppPermissionStatus.granted) {
@@ -68,87 +123,118 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen>
   }
 
   Future<void> _pickImage() async {
-    // Checks camera permission before opening
-    final status = await PermissionService.checkCamera();
-    if (!mounted) return;
+    // Re-entry guard: prevents a rapid double tap from opening two pickers
+    // (and firing duplicate location/classification work).
+    if (_isCapturing) return;
+    _isCapturing = true;
 
-    if (status != AppPermissionStatus.granted) {
-      final requestStatus = await PermissionService.requestCamera();
+    XFile? image;
+    try {
+      final status = await _checkCameraPermission();
       if (!mounted) return;
 
-      if (requestStatus != AppPermissionStatus.granted) {
-        setState(() => _cameraPermissionStatus = requestStatus);
-        return;
-      }
-    }
-    // Clears the permission state if granted
-    if (_cameraPermissionStatus != null) {
-      setState(() => _cameraPermissionStatus = null);
-    }
+      if (status != AppPermissionStatus.granted) {
+        final requestStatus = await _requestCameraPermission();
+        if (!mounted) return;
 
-    final picker = ImagePicker();
-    final XFile? image = await picker.pickImage(source: ImageSource.camera);
+        if (requestStatus != AppPermissionStatus.granted) {
+          setState(() => _cameraPermissionStatus = requestStatus);
+          return;
+        }
+      }
+      // Clears the permission state if granted
+      if (_cameraPermissionStatus != null) {
+        setState(() => _cameraPermissionStatus = null);
+      }
+
+      image = await _pickFromCamera();
+    } catch (e) {
+      developer.log('Camera capture failed: $e', name: 'CaptureScreen');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Não foi possível abrir a câmera.')),
+        );
+      }
+      return;
+    } finally {
+      _isCapturing = false;
+    }
 
     if (!mounted || image == null) return;
 
     ref.read(imageProvider.notifier).setImage(File(image.path));
 
+    // Tags this capture so late results from a superseded one are ignored.
+    final generation = ++_requestGeneration;
     setState(() {
       _address = null;
       _latitude = null;
       _longitude = null;
       _classificationResult = null;
+      _classificationFailed = false;
     });
 
     // Runs location and classification in parallel (they are independent)
     await Future.wait([
-      _fetchCurrentLocation(),
-      _classifySoilTexture(image.path),
+      _fetchCurrentLocation(generation),
+      _classifySoilTexture(image.path, generation),
     ]);
   }
 
-  Future<void> _classifySoilTexture(String imagePath) async {
-    setState(() => _isClassifying = true);
+  Future<void> _classifySoilTexture(String imagePath, int generation) async {
+    if (mounted) {
+      setState(() {
+        _isClassifying = true;
+        _classificationFailed = false;
+      });
+    }
 
+    InferenceResult? result;
     try {
       final inferenceService = ref.read(inferenceServiceProvider);
-      final result = await inferenceService.classify(imagePath);
-
-      if (mounted) {
-        setState(() {
-          _classificationResult = result;
-          _isClassifying = false;
-        });
-      }
+      result = await inferenceService
+          .classify(imagePath)
+          .timeout(_classificationTimeout, onTimeout: () => null);
     } catch (e) {
-      if (mounted) {
-        setState(() => _isClassifying = false);
-      }
+      developer.log('Classification failed: $e', name: 'CaptureScreen');
+      result = null;
     }
+
+    if (!mounted || generation != _requestGeneration) return;
+    setState(() {
+      _classificationResult = result;
+      _classificationFailed = result == null;
+      _isClassifying = false;
+    });
   }
 
-  Future<void> _fetchCurrentLocation() async {
-    setState(() => _isLoading = true);
+  Future<void> _fetchCurrentLocation(int generation) async {
+    if (mounted) setState(() => _isLoading = true);
 
+    LocationReading? reading;
     try {
-      final position = await LocationService.getCurrentLocation();
-      final address = await LocationService.getAddressFromPosition(position);
-
-      if (mounted) {
-        setState(() {
-          _latitude = position.latitude;
-          _longitude = position.longitude;
-          _address = address;
-          _isLoading = false;
-        });
-      }
-    } catch (e) {
-      // Location denied or unavailable: the app works without GPS
-      // The record will be saved with null coordinates
-      if (mounted) {
-        setState(() => _isLoading = false);
-      }
+      reading =
+          await _locate().timeout(_locationTimeout, onTimeout: () => null);
+    } catch (_) {
+      // Location is optional: the record can be saved without coordinates.
+      reading = null;
     }
+
+    if (!mounted || generation != _requestGeneration) return;
+    setState(() {
+      if (reading != null) {
+        _latitude = reading.latitude;
+        _longitude = reading.longitude;
+        _address = reading.address;
+      }
+      _isLoading = false;
+    });
+  }
+
+  void _retryClassification() {
+    final image = ref.read(imageProvider).file;
+    if (image == null) return;
+    _classifySoilTexture(image.path, _requestGeneration);
   }
 
   Future<void> _saveRecord() async {
@@ -194,12 +280,15 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen>
   }
 
   void _discardImage() {
+    // Invalidates any in-flight location/classification work for this capture.
+    _requestGeneration++;
     ref.read(imageProvider.notifier).clearImage();
     setState(() {
       _address = null;
       _latitude = null;
       _longitude = null;
       _classificationResult = null;
+      _classificationFailed = false;
     });
   }
 
@@ -254,6 +343,8 @@ class _CaptureScreenState extends ConsumerState<CaptureScreen>
                   isClassifying: _isClassifying,
                   address: _address,
                   classificationResult: _classificationResult,
+                  classificationFailed: _classificationFailed,
+                  onRetryClassification: _retryClassification,
                 ),
               ),
               const SizedBox(height: AppSpacing.lg),
@@ -297,6 +388,8 @@ class _ImagePreview extends StatelessWidget {
     required this.isClassifying,
     this.address,
     this.classificationResult,
+    this.classificationFailed = false,
+    this.onRetryClassification,
   });
 
   final File? image;
@@ -304,6 +397,8 @@ class _ImagePreview extends StatelessWidget {
   final bool isClassifying;
   final String? address;
   final InferenceResult? classificationResult;
+  final bool classificationFailed;
+  final VoidCallback? onRetryClassification;
 
   @override
   Widget build(BuildContext context) {
@@ -415,6 +510,16 @@ class _ImagePreview extends StatelessWidget {
       return _InfoChip(
         icon: Icons.eco,
         label: '${classificationResult!.textureClass} · $confidence%',
+      );
+    }
+    if (classificationFailed) {
+      return GestureDetector(
+        key: const Key('retryClassification'),
+        onTap: onRetryClassification,
+        child: const _InfoChip(
+          icon: Icons.refresh,
+          label: 'Classificação falhou · tocar para repetir',
+        ),
       );
     }
     return const _InfoChip(

--- a/test/features/capture/capture_screen_test.dart
+++ b/test/features/capture/capture_screen_test.dart
@@ -1,0 +1,164 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:image_picker/image_picker.dart';
+import 'package:visiosoil_app/core/features/capture/capture_screen.dart';
+import 'package:visiosoil_app/core/services/inference_service.dart';
+import 'package:visiosoil_app/core/services/permission_service.dart';
+import 'package:visiosoil_app/providers/inference_provider.dart';
+
+class _FakeInference extends InferenceService {
+  _FakeInference(this._handler);
+
+  final Future<InferenceResult?> Function(String imagePath) _handler;
+
+  @override
+  Future<InferenceResult?> classify(String imagePath) => _handler(imagePath);
+}
+
+void main() {
+  late String samplePath;
+
+  setUpAll(() {
+    final dir = Directory.systemTemp.createTempSync('capture_screen_test');
+    final file = File('${dir.path}/sample.png');
+    file.writeAsBytesSync(img.encodePng(img.Image(width: 8, height: 8)));
+    samplePath = file.path;
+  });
+
+  Widget buildScreen({
+    required CameraImagePicker pickFromCamera,
+    required LocationResolver locate,
+    required Future<InferenceResult?> Function(String) classify,
+  }) {
+    return ProviderScope(
+      overrides: [
+        inferenceServiceProvider.overrideWithValue(_FakeInference(classify)),
+      ],
+      child: MaterialApp(
+        home: CaptureScreen(
+          pickFromCamera: pickFromCamera,
+          locate: locate,
+          checkCameraPermission: () async => AppPermissionStatus.granted,
+          requestCameraPermission: () async => AppPermissionStatus.granted,
+        ),
+      ),
+    );
+  }
+
+  // Flushes the permission -> pick -> setImage -> start-futures async chain.
+  Future<void> capture(WidgetTester tester) async {
+    await tester.tap(find.text('Câmera'));
+    for (var i = 0; i < 6; i++) {
+      await tester.pump(const Duration(milliseconds: 10));
+    }
+  }
+
+  testWidgets('a camera picker failure shows a snackbar and keeps the screen',
+      (tester) async {
+    await tester.pumpWidget(buildScreen(
+      pickFromCamera: () async => throw PlatformException(code: 'camera_error'),
+      locate: () async => null,
+      classify: (_) async => null,
+    ));
+
+    await capture(tester);
+
+    expect(find.byType(SnackBar), findsOneWidget);
+    expect(find.text('Câmera'), findsOneWidget);
+  });
+
+  testWidgets('a failed classification shows a retry affordance',
+      (tester) async {
+    await tester.pumpWidget(buildScreen(
+      pickFromCamera: () async => XFile(samplePath),
+      locate: () async => null,
+      classify: (_) async => null,
+    ));
+
+    await capture(tester);
+
+    expect(find.byKey(const Key('retryClassification')), findsOneWidget);
+  });
+
+  testWidgets('tapping retry reruns classification and shows the result',
+      (tester) async {
+    var calls = 0;
+    await tester.pumpWidget(buildScreen(
+      pickFromCamera: () async => XFile(samplePath),
+      locate: () async => null,
+      classify: (_) async {
+        calls++;
+        if (calls == 1) return null;
+        return const InferenceResult(
+          textureClass: 'Argilosa',
+          confidenceScore: 0.9,
+        );
+      },
+    ));
+
+    await capture(tester);
+    expect(find.byKey(const Key('retryClassification')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('retryClassification')));
+    for (var i = 0; i < 6; i++) {
+      await tester.pump(const Duration(milliseconds: 10));
+    }
+
+    expect(find.textContaining('Argilosa'), findsOneWidget);
+  });
+
+  testWidgets('a hanging classification times out and shows the retry affordance',
+      (tester) async {
+    final never = Completer<InferenceResult?>();
+    await tester.pumpWidget(buildScreen(
+      pickFromCamera: () async => XFile(samplePath),
+      locate: () async => null,
+      classify: (_) => never.future,
+    ));
+
+    await capture(tester);
+    expect(find.byKey(const Key('retryClassification')), findsNothing);
+
+    await tester.pump(const Duration(seconds: 21));
+
+    expect(find.byKey(const Key('retryClassification')), findsOneWidget);
+  });
+
+  testWidgets('a late result from a discarded capture does not overwrite a newer one',
+      (tester) async {
+    final firstClassify = Completer<InferenceResult?>();
+    var calls = 0;
+    await tester.pumpWidget(buildScreen(
+      pickFromCamera: () async => XFile(samplePath),
+      locate: () async => null,
+      classify: (_) {
+        calls++;
+        if (calls == 1) return firstClassify.future;
+        return Future.value(
+          const InferenceResult(textureClass: 'Media', confidenceScore: 0.7),
+        );
+      },
+    ));
+
+    await capture(tester);
+    await tester.tap(find.text('Descartar'));
+    await tester.pump();
+    await capture(tester);
+
+    firstClassify.complete(
+      const InferenceResult(textureClass: 'Argilosa', confidenceScore: 0.9),
+    );
+    for (var i = 0; i < 6; i++) {
+      await tester.pump(const Duration(milliseconds: 10));
+    }
+
+    expect(find.textContaining('Media'), findsOneWidget);
+    expect(find.textContaining('Argilosa'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Context

- **Motivation:** In `CaptureScreen`, discarding/re-capturing did not invalidate in-flight location/classification work (stale results repopulated the UI), classification failures were invisible with no retry, async work had no timeout (Save could stay disabled forever), and `ImagePicker.pickImage` failures could escape uncaught.
- **Task Link:** Closes #22
- **Spec Link:** Approved at the Spec Gate — embedded below (kept out of `main` per the project's ephemeral-spec practice).
- **Also resolves:** the location-throttling deferred from #24 — the re-entry guard prevents a rapid double tap from firing parallel capture/location work.

## What Was Done

All within `lib/core/features/capture/capture_screen.dart`:
- Added a monotonic **generation token**: `_pickImage` increments it per capture and `_discardImage` increments it on clear; location and classification apply their `setState` only when `mounted && generation == _requestGeneration`, so results from a discarded/superseded capture are dropped.
- Added an `_isCapturing` re-entry guard around the permission+picker phase (covers #24's throttling).
- Added `.timeout` to location and classification; on timeout they route to the failure path (location → no GPS; classification → failed).
- Wrapped the camera pick in try/catch with an error `SnackBar`.
- Added a `_classificationFailed` state and a tappable retry affordance (`Key('retryClassification')`) that re-runs classification for the current image.
- Added optional in-file dependency seams (camera picker, location resolver, permission check/request) defaulting to the real implementations, so the flow is widget-testable. `const CaptureScreen()` (router) is unchanged via the null defaults.

## How to Test

1. Check out the branch.
2. `flutter pub get`
3. `flutter test test/features/capture/capture_screen_test.dart` — 5 cases pass.
4. `flutter analyze` — no issues.

## Evidence

`flutter test`: 28/28 pass on this branch (23 existing + 5 new widget tests). `flutter analyze`: "No issues found!". The visible change is a tappable "Classificação falhou · tocar para repetir" chip on failure.

## Self-Review Checklist

- [x] Self-review done in the Files Changed tab.
- [x] Spec approved at the Gate before implementation; the change matches its Scope (no other files touched).
- [x] Each Acceptance Criterion has a passing test, committed first (`test(capture): ...`, red) before the implementation (`fix(capture): ...`, green).
- [x] No commented-out code or debug statements.
- [x] Code follows the project style guide; `flutter analyze` clean.
- [x] No new dependencies.
- **Review layers:** R1 — author self-review per `ai_guidelines.md`. R2 — no second-provider reviewer configured; R1 plus human PR review stand in. R3 — CodeRabbit on this PR.

---

## SPEC (approved at the Gate)

# SPEC: fix(capture): cancel stale async work and surface capture failures

### Problem
In `CaptureScreen`, discarding or re-capturing an image does not invalidate in-flight location/classification work (stale results repopulate the UI), classification failures are invisible with no retry, async work has no timeout (the Save button can stay disabled forever), and `ImagePicker.pickImage` failures can escape uncaught.

### Design Decision
Tag each capture with a monotonic generation token; every async completion applies its `setState` only if `mounted && generation == _requestGeneration`, dropping results from a discarded/superseded capture. A re-entry guard prevents overlapping capture flows (covers #24's deferred throttling). Wrap `pickImage` in try/catch with a `SnackBar`. Apply `.timeout` to location and classification; on timeout treat them as failed. Track a `_classificationFailed` flag and render a tappable retry affordance. Add optional in-file dependency seams (picker, location resolver, permission check/request) defaulting to the real implementations so the flow is testable; `const CaptureScreen()` keeps working via null defaults.

### Alternatives Considered
1. Convert `LocationService`/`PermissionService` to Riverpod-provided instances — rejected: edits files outside this issue's scope and re-opens the static-vs-instance decision deferred in #24; the in-file seams default to those statics.
2. `CancelableOperation`/stream cancellation — rejected: `Isolate.run` and the static futures aren't truly cancellable; an ignore-late-result token guard is the honest, testable model.
3. Skip widget tests (UI coverage tracked in #27) — rejected: violates test-first policy; the seams make the race fixes testable now.

### Scope
- **Includes (all in `capture_screen.dart`):** generation-token guard (#1); re-entry guard (covers #24 throttling); `.timeout` on location & classification (#3); try/catch + SnackBar around the picker (#4); classification-failure state + retry affordance (#2); optional in-file DI seams; widget tests.
- **Does NOT include:** converting service usage to providers in their own files; changes to those services, the repository, or routing; broader CaptureScreen coverage (→ #27); chip restyling/copy beyond the retry affordance.

### Acceptance Criteria
1. `discarding_an_image_drops_a_late_classification_result`
2. `a_new_capture_supersedes_the_previous_in_flight_classification`
3. `a_camera_picker_failure_shows_a_snackbar_and_keeps_the_screen`
4. `a_failed_classification_shows_a_retry_affordance`
5. `tapping_retry_reruns_classification_and_shows_the_result`
6. `a_hanging_classification_times_out_and_leaves_the_failed_state`

(Criteria 1 and 2 are covered by a single test exercising discard + supersede with a late result.)

### Reproducibility
`flutter test test/features/capture/capture_screen_test.dart` (Flutter 3.38.5 / Dart 3.10.4); full gate `flutter analyze` + `flutter test`. Timeout cases use the fake-async clock (`tester.pump(duration)`).

### Risks and Assumptions
- Optional nullable constructor params preserve the `const CaptureScreen()` call site (null/const defaults).
- A generation-token guard ignores late results rather than aborting them (the isolate/futures aren't truly cancellable).
- Widget tests must drive permission → picker → location → classify via the seams; all three platform seams are injected to avoid `MissingPluginException`.
